### PR TITLE
이미지 업로드 인풋을 하나의 컴포넌트로 분리하기	

### DIFF
--- a/src/components/molecules/ImageUploadInput/ImageUploadInput.stories.tsx
+++ b/src/components/molecules/ImageUploadInput/ImageUploadInput.stories.tsx
@@ -1,0 +1,32 @@
+import { ChangeEventHandler, useState } from 'react';
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import readFileAsURL from '../../../utils/readFileAsURL';
+import ImageUploadInput from './index';
+
+export default {
+  title: 'molecules/ImageUploadInput',
+  component: ImageUploadInput
+} as ComponentMeta<typeof ImageUploadInput>;
+
+export const Primary: ComponentStory<typeof ImageUploadInput> = () => {
+  const [profileImage, setProfileImage] = useState('');
+
+  const handleChangeImageFile: ChangeEventHandler<HTMLInputElement> = ({
+    target: { files }
+  }) => {
+    if (!files) return;
+    const file = files[0];
+    readFileAsURL(file, (url) => setProfileImage(url));
+  };
+
+  const handleClickDeleteImage = () => setProfileImage('');
+
+  return (
+    <ImageUploadInput
+      profileImage={profileImage}
+      onChangeImageFile={handleChangeImageFile}
+      onClickDeleteImage={handleClickDeleteImage}
+    />
+  );
+};

--- a/src/components/molecules/ImageUploadInput/index.tsx
+++ b/src/components/molecules/ImageUploadInput/index.tsx
@@ -1,0 +1,103 @@
+import { ChangeEventHandler } from 'react';
+import styled from '@emotion/styled';
+
+import colors from '../../../styles/colors';
+import { FilledCancel, Upload } from '../../atoms/icons';
+
+type ImageUploadInputProps = {
+  onChange: ChangeEventHandler<HTMLInputElement>;
+};
+
+const UploadIcon = styled(Upload)`
+  height: 44px;
+`;
+
+const UploadDiscription = styled.span`
+  margin-top: 4px;
+  color: ${colors.grayScale.gray03};
+`;
+
+const ProfileImageInputLabel = styled.label`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 250px;
+  background-color: ${colors.grayScale.gray01};
+  cursor: pointer;
+`;
+
+const ProfileImageInput = styled.input`
+  display: none;
+`;
+
+const ImageInput = ({ onChange }: ImageUploadInputProps) => {
+  return (
+    <>
+      <ProfileImageInputLabel htmlFor="image-input">
+        <UploadIcon width="44px" color={colors.grayScale.gray03} />
+        <UploadDiscription>모임 대표 사진을 업로드해보세요.</UploadDiscription>
+      </ProfileImageInputLabel>
+      <ProfileImageInput
+        type="file"
+        id="image-input"
+        value=""
+        accept="image/*"
+        onChange={onChange}
+      />
+    </>
+  );
+};
+
+type ThumbnailImageContainer = {
+  src: string;
+  onClick: () => void;
+};
+
+const ImageContainer = styled.div`
+  position: relative;
+  height: 250px;
+`;
+
+const ThumbnailImage = styled.img`
+  width: 100%;
+  height: 250px;
+  object-fit: cover;
+`;
+
+const DeleteImageButton = styled.button`
+  position: absolute;
+  top: 15px;
+  right: 13px;
+`;
+
+const ThumbnailImageContainer = ({ src, onClick }: ThumbnailImageContainer) => {
+  return (
+    <ImageContainer>
+      <ThumbnailImage alt="모임 프로필" src={src} />
+      <DeleteImageButton onClick={onClick}>
+        <FilledCancel />
+      </DeleteImageButton>
+    </ImageContainer>
+  );
+};
+
+type Props = {
+  profileImage: string;
+  onClickDeleteImage: () => void;
+  onChangeImageFile: ChangeEventHandler<HTMLInputElement>;
+};
+
+const ImageUploadInput = ({
+  profileImage,
+  onChangeImageFile,
+  onClickDeleteImage
+}: Props) => {
+  return profileImage ? (
+    <ThumbnailImageContainer src={profileImage} onClick={onClickDeleteImage} />
+  ) : (
+    <ImageInput onChange={onChangeImageFile} />
+  );
+};
+
+export default ImageUploadInput;

--- a/src/components/molecules/index.ts
+++ b/src/components/molecules/index.ts
@@ -1,5 +1,6 @@
 export { default as Dialog } from './Dialog';
 export { default as GPSButton } from './GPSButton';
+export { default as ImageUploadInput } from './ImageUploadInput';
 export { default as RadioButton } from './RadioButton';
 export { default as SegmentTab } from './SegmentTab';
 export { default as Stepper } from './Stepper';

--- a/src/pages/group/make-form-basic.tsx
+++ b/src/pages/group/make-form-basic.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @next/next/no-img-element */
-import { ChangeEventHandler, RefObject, useRef, useState } from 'react';
+import { ChangeEventHandler, useState } from 'react';
 import Router from 'next/router';
 import styled from '@emotion/styled';
 
@@ -62,7 +62,7 @@ const ImageUploadInput = ({ onChange }: ImageUploadInputProps) => {
 };
 
 type ThumbnailImageContainer = {
-  imageRef: RefObject<HTMLImageElement>;
+  src: string;
   onClick: () => void;
 };
 
@@ -83,13 +83,10 @@ const DeleteImageButton = styled.button`
   right: 13px;
 `;
 
-const ThumbnailImageContainer = ({
-  imageRef,
-  onClick
-}: ThumbnailImageContainer) => {
+const ThumbnailImageContainer = ({ src, onClick }: ThumbnailImageContainer) => {
   return (
     <ImageContainer>
-      <ThumbnailImage alt="모임 프로필" ref={imageRef} />
+      <ThumbnailImage alt="모임 프로필" src={src} />
       <DeleteImageButton onClick={onClick}>
         <FilledCancel />
       </DeleteImageButton>
@@ -124,10 +121,8 @@ const MakeFormBasic = () => {
   const [description, setDescription] = useState('');
   const [numberOfPeople, setNumberOfPeople] = useState(0);
   const [tagList, setTagList] = useState<string[]>([]);
-  const [isImageAttached, setIsImageAttached] = useState(false);
+  const [profileImage, setProfileImage] = useState('');
   const [isModalDisplay, setIsModalDisplay] = useState(false);
-
-  const imageRef = useRef<HTMLImageElement>(null);
 
   const handleGroupNameChange: ChangeEventHandler<HTMLInputElement> = ({
     target: { value }
@@ -169,24 +164,17 @@ const MakeFormBasic = () => {
     const file = files[0];
     const fileReader = new FileReader();
     fileReader.addEventListener('load', ({ target }) => {
-      if (!target || !imageRef.current) return;
+      if (!target) return;
       const { result } = target;
       if (typeof result !== 'string') return;
-      imageRef.current.src = result;
+      setProfileImage(result);
     });
     fileReader.readAsDataURL(file);
-    setIsImageAttached(true);
   };
 
-  const handleClickDeleteImage = () => {
-    if (!imageRef.current) return;
-    imageRef.current.src = '';
-    setIsImageAttached(false);
-  };
+  const handleClickDeleteImage = () => setProfileImage('');
 
-  const backConfirmCallback = () => {
-    setIsModalDisplay(true);
-  };
+  const backConfirmCallback = () => setIsModalDisplay(true);
 
   return (
     <>
@@ -213,9 +201,9 @@ const MakeFormBasic = () => {
         <WhiteBox hasMargin={false}>
           <Title>새로운 모임을 만들어보세요.</Title>
         </WhiteBox>
-        {isImageAttached ? (
+        {profileImage ? (
           <ThumbnailImageContainer
-            imageRef={imageRef}
+            src={profileImage}
             onClick={handleClickDeleteImage}
           />
         ) : (

--- a/src/pages/group/make-form-basic.tsx
+++ b/src/pages/group/make-form-basic.tsx
@@ -3,9 +3,9 @@ import { ChangeEventHandler, useState } from 'react';
 import Router from 'next/router';
 import styled from '@emotion/styled';
 
-import { FilledCancel, Upload } from '../../components/atoms/icons';
 import {
   Dialog,
+  ImageUploadInput,
   Stepper,
   TagInput,
   TextArea,
@@ -15,84 +15,7 @@ import {
 import ButtonFooter from '../../components/molecules/ButtonFooter';
 import colors from '../../styles/colors';
 import { semiBold20 } from '../../styles/typography';
-
-type ImageUploadInputProps = {
-  onChange: ChangeEventHandler<HTMLInputElement>;
-};
-
-const UploadIcon = styled(Upload)`
-  height: 44px;
-`;
-
-const UploadDiscription = styled.span`
-  margin-top: 4px;
-  color: ${colors.grayScale.gray03};
-`;
-
-const ProfileImageInputLabel = styled.label`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  height: 250px;
-  background-color: ${colors.grayScale.gray01};
-  cursor: pointer;
-`;
-
-const ProfileImageInput = styled.input`
-  display: none;
-`;
-
-const ImageUploadInput = ({ onChange }: ImageUploadInputProps) => {
-  return (
-    <>
-      <ProfileImageInputLabel htmlFor="image-input">
-        <UploadIcon width="44px" color={colors.grayScale.gray03} />
-        <UploadDiscription>모임 대표 사진을 업로드해보세요.</UploadDiscription>
-      </ProfileImageInputLabel>
-      <ProfileImageInput
-        type="file"
-        id="image-input"
-        value=""
-        accept="image/*"
-        onChange={onChange}
-      />
-    </>
-  );
-};
-
-type ThumbnailImageContainer = {
-  src: string;
-  onClick: () => void;
-};
-
-const ImageContainer = styled.div`
-  position: relative;
-  height: 250px;
-`;
-
-const ThumbnailImage = styled.img`
-  width: 100%;
-  height: 250px;
-  object-fit: cover;
-`;
-
-const DeleteImageButton = styled.button`
-  position: absolute;
-  top: 15px;
-  right: 13px;
-`;
-
-const ThumbnailImageContainer = ({ src, onClick }: ThumbnailImageContainer) => {
-  return (
-    <ImageContainer>
-      <ThumbnailImage alt="모임 프로필" src={src} />
-      <DeleteImageButton onClick={onClick}>
-        <FilledCancel />
-      </DeleteImageButton>
-    </ImageContainer>
-  );
-};
+import readFileAsURL from '../../utils/readFileAsURL';
 
 const Background = styled.div`
   min-height: 100vh;
@@ -121,8 +44,18 @@ const MakeFormBasic = () => {
   const [description, setDescription] = useState('');
   const [numberOfPeople, setNumberOfPeople] = useState(0);
   const [tagList, setTagList] = useState<string[]>([]);
-  const [profileImage, setProfileImage] = useState('');
   const [isModalDisplay, setIsModalDisplay] = useState(false);
+  const [profileImage, setProfileImage] = useState('');
+
+  const handleChangeImageFile: ChangeEventHandler<HTMLInputElement> = ({
+    target: { files }
+  }) => {
+    if (!files) return;
+    const file = files[0];
+    readFileAsURL(file, (url) => setProfileImage(url));
+  };
+
+  const handleClickDeleteImage = () => setProfileImage('');
 
   const handleGroupNameChange: ChangeEventHandler<HTMLInputElement> = ({
     target: { value }
@@ -157,23 +90,6 @@ const MakeFormBasic = () => {
     });
   };
 
-  const handleChangeImageFile: ChangeEventHandler<HTMLInputElement> = ({
-    target: { files }
-  }) => {
-    if (!files) return;
-    const file = files[0];
-    const fileReader = new FileReader();
-    fileReader.addEventListener('load', ({ target }) => {
-      if (!target) return;
-      const { result } = target;
-      if (typeof result !== 'string') return;
-      setProfileImage(result);
-    });
-    fileReader.readAsDataURL(file);
-  };
-
-  const handleClickDeleteImage = () => setProfileImage('');
-
   const backConfirmCallback = () => setIsModalDisplay(true);
 
   return (
@@ -201,14 +117,11 @@ const MakeFormBasic = () => {
         <WhiteBox hasMargin={false}>
           <Title>새로운 모임을 만들어보세요.</Title>
         </WhiteBox>
-        {profileImage ? (
-          <ThumbnailImageContainer
-            src={profileImage}
-            onClick={handleClickDeleteImage}
-          />
-        ) : (
-          <ImageUploadInput onChange={handleChangeImageFile} />
-        )}
+        <ImageUploadInput
+          profileImage={profileImage}
+          onChangeImageFile={handleChangeImageFile}
+          onClickDeleteImage={handleClickDeleteImage}
+        />
         <WhiteBox hasMargin={false}>
           <GroupNameInput
             label="모임 이름"

--- a/src/utils/readFileAsURL.ts
+++ b/src/utils/readFileAsURL.ts
@@ -1,0 +1,12 @@
+const readFileAsURL = (file: File, callback: (url: string) => void) => {
+  const fileReader = new FileReader();
+  fileReader.addEventListener('load', ({ target }) => {
+    if (!target) return;
+    const { result } = target;
+    if (typeof result !== 'string') return;
+    callback(result);
+  });
+  fileReader.readAsDataURL(file);
+};
+
+export default readFileAsURL;


### PR DESCRIPTION
resolved #156

- 모임 만들기 페이지에 쓰이는 이미지 업로드 인풋이 모임 설정 페이지에서도 쓰일 예정임에 따라 공통 컴포넌트로 분리했습니다.
- 또한, `FileReader`를 사용하여 이미지 파일을 URL로 읽어오는 로직을 분리하여 `readFileAsURL`이라는 이름의 함수로 만들었습니다.