### PR TITLE
모임 만들기 과정에 전역 상태 관리 적용하기

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "next": "12.2.3",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "react-responsive-carousel": "^3.2.23"
+    "react-responsive-carousel": "^3.2.23",
+    "zustand": "^4.1.2"
   },
   "devDependencies": {
     "@babel/core": "^7.18.10",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "eslint-plugin-simple-import-sort": "^7.0.0",
     "eslint-plugin-unused-imports": "^2.0.0",
     "prettier": "^2.7.1",
+    "simple-zustand-devtools": "^1.1.0",
     "typescript": "4.7.4"
   },
   "readme": "ERROR: No README data found!",

--- a/src/pages/group/make-form-additional.tsx
+++ b/src/pages/group/make-form-additional.tsx
@@ -115,11 +115,14 @@ const MakeFormAdditional = () => {
   );
   const [penaltyCount, setPenaltyCount] = useState(0);
   const [isPublic, SetIsPublic] = useState<1 | 2>(1);
-  const setGifticonIDStore = useNewGroupInformationStore(
-    (state) => state.setGifticonID
+  const profileImageURL = useNewGroupInformationStore(
+    (state) => state.profileImageURL
   );
-  const setMaximumNumberOfPenaltyStore = useNewGroupInformationStore(
-    (state) => state.setMaximumNumberOfPenalty
+  const name = useNewGroupInformationStore((state) => state.name);
+  const description = useNewGroupInformationStore((state) => state.description);
+  const tags = useNewGroupInformationStore((state) => state.tags);
+  const numberOfMembers = useNewGroupInformationStore(
+    (state) => state.numberOfMembers
   );
 
   const handleGifticonSelect = (gifticon: Gifticon) =>
@@ -138,8 +141,16 @@ const MakeFormAdditional = () => {
   }) => SetIsPublic(parseInt(value) as 1 | 2);
 
   const handleNextButtonClick = () => {
-    setGifticonIDStore(selectedGifticon.id);
-    setMaximumNumberOfPenaltyStore(penaltyCount);
+    console.log({
+      profileImageURL,
+      name,
+      description,
+      tags,
+      numberOfMembers,
+      selectedGifticonID: selectedGifticon.id,
+      penaltyCount
+    });
+
     Router.push('./make-success');
   };
 

--- a/src/pages/group/make-form-additional.tsx
+++ b/src/pages/group/make-form-additional.tsx
@@ -7,6 +7,7 @@ import { Thumbnail } from '../../components/atoms';
 import { Warning } from '../../components/atoms/icons';
 import { RadioButton, Stepper, TopNavBar } from '../../components/molecules';
 import ButtonFooter from '../../components/molecules/ButtonFooter';
+import useNewGroupInformationStore from '../../store/newGroupInformation';
 import colors from '../../styles/colors';
 import {
   bold16,
@@ -109,9 +110,17 @@ const WarningWithMargin = styled(Warning)`
 `;
 
 const MakeFormAdditional = () => {
-  const [selectedGifticon, setSelectedGifticon] = useState<Gifticon>();
+  const [selectedGifticon, setSelectedGifticon] = useState<Gifticon>(
+    GIFTICON_MOCK[0]
+  );
   const [penaltyCount, setPenaltyCount] = useState(0);
   const [isPublic, SetIsPublic] = useState<1 | 2>(1);
+  const setGifticonIDStore = useNewGroupInformationStore(
+    (state) => state.setGifticonID
+  );
+  const setMaximumNumberOfPenaltyStore = useNewGroupInformationStore(
+    (state) => state.setMaximumNumberOfPenalty
+  );
 
   const handleGifticonSelect = (gifticon: Gifticon) =>
     setSelectedGifticon(gifticon);
@@ -127,6 +136,12 @@ const MakeFormAdditional = () => {
   const handleIsPublicChange: ChangeEventHandler<HTMLInputElement> = ({
     target: { value }
   }) => SetIsPublic(parseInt(value) as 1 | 2);
+
+  const handleNextButtonClick = () => {
+    setGifticonIDStore(selectedGifticon.id);
+    setMaximumNumberOfPenaltyStore(penaltyCount);
+    Router.push('./make-success');
+  };
 
   return (
     <Background>
@@ -211,7 +226,7 @@ const MakeFormAdditional = () => {
       </WhiteBox>
       <ButtonFooter
         disabled={!(selectedGifticon && penaltyCount)}
-        onClick={() => Router.push('./make-success')}
+        onClick={handleNextButtonClick}
       >
         모임비 결제하기
       </ButtonFooter>

--- a/src/pages/group/make-form-basic.tsx
+++ b/src/pages/group/make-form-basic.tsx
@@ -13,6 +13,7 @@ import {
   TopNavBar
 } from '../../components/molecules';
 import ButtonFooter from '../../components/molecules/ButtonFooter';
+import useNewGroupInformationStore from '../../store/newGroupInformation';
 import colors from '../../styles/colors';
 import { semiBold20 } from '../../styles/typography';
 import readFileAsURL from '../../utils/readFileAsURL';
@@ -46,6 +47,17 @@ const MakeFormBasic = () => {
   const [tagList, setTagList] = useState<string[]>([]);
   const [isModalDisplay, setIsModalDisplay] = useState(false);
   const [profileImage, setProfileImage] = useState('');
+  const setProfileImageURLStore = useNewGroupInformationStore(
+    (state) => state.setProfileImageURL
+  );
+  const setNameStore = useNewGroupInformationStore((state) => state.setName);
+  const setDescriptionStore = useNewGroupInformationStore(
+    (state) => state.setDescription
+  );
+  const setTagsStore = useNewGroupInformationStore((state) => state.setTags);
+  const setNumberOfMembersStore = useNewGroupInformationStore(
+    (state) => state.setNumberOfMembers
+  );
 
   const handleChangeImageFile: ChangeEventHandler<HTMLInputElement> = ({
     target: { files }
@@ -77,6 +89,12 @@ const MakeFormBasic = () => {
 
   const handleButtonClick = () => {
     if (!isValueExist()) return;
+
+    setProfileImageURLStore(profileImage);
+    setNameStore(groupName);
+    setDescriptionStore(description);
+    setTagsStore(tagList);
+    setNumberOfMembersStore(numberOfPeople);
     Router.push('./make-form-additional');
   };
 

--- a/src/store/newGroupInformation.ts
+++ b/src/store/newGroupInformation.ts
@@ -1,3 +1,4 @@
+import { mountStoreDevtool } from 'simple-zustand-devtools';
 import create from 'zustand';
 
 type GroupInformationState = {
@@ -34,5 +35,7 @@ const useNewGroupInformationStore = create<GroupInformationState>((set) => ({
   setMaximumNumberOfPenalty: (maximumNumberOfPenalty: number) =>
     set({ maximumNumberOfPenalty })
 }));
+
+mountStoreDevtool('NewGroupInformation', useNewGroupInformationStore);
 
 export default useNewGroupInformationStore;

--- a/src/store/newGroupInformation.ts
+++ b/src/store/newGroupInformation.ts
@@ -14,8 +14,6 @@ type GroupInformationState = {
   setDescription: (description: string) => void;
   setTags: (tags: string[]) => void;
   setNumberOfMembers: (numberOfMembers: number) => void;
-  setGifticonID: (gifticonID: string) => void;
-  setMaximumNumberOfPenalty: (maximumNumberOfPenalty: number) => void;
 };
 
 const useNewGroupInformationStore = create<GroupInformationState>((set) => ({
@@ -30,10 +28,7 @@ const useNewGroupInformationStore = create<GroupInformationState>((set) => ({
   setName: (name: string) => set({ name }),
   setDescription: (description: string) => set({ description }),
   setTags: (tags: string[]) => set({ tags }),
-  setNumberOfMembers: (numberOfMembers: number) => set({ numberOfMembers }),
-  setGifticonID: (gifticonID: string) => set({ gifticonID }),
-  setMaximumNumberOfPenalty: (maximumNumberOfPenalty: number) =>
-    set({ maximumNumberOfPenalty })
+  setNumberOfMembers: (numberOfMembers: number) => set({ numberOfMembers })
 }));
 
 mountStoreDevtool('NewGroupInformation', useNewGroupInformationStore);

--- a/src/store/newGroupInformation.ts
+++ b/src/store/newGroupInformation.ts
@@ -1,0 +1,38 @@
+import create from 'zustand';
+
+type GroupInformationState = {
+  profileImageURL: string;
+  name: string;
+  description: string;
+  tags: string[];
+  numberOfMembers: number;
+  gifticonID: string;
+  maximumNumberOfPenalty: number;
+  setProfileImageURL: (profileImageURL: string) => void;
+  setName: (name: string) => void;
+  setDescription: (description: string) => void;
+  setTags: (tags: string[]) => void;
+  setNumberOfMembers: (numberOfMembers: number) => void;
+  setGifticonID: (gifticonID: string) => void;
+  setMaximumNumberOfPenalty: (maximumNumberOfPenalty: number) => void;
+};
+
+const useNewGroupInformationStore = create<GroupInformationState>((set) => ({
+  profileImageURL: '',
+  name: '',
+  description: '',
+  tags: [],
+  numberOfMembers: 0,
+  gifticonID: '',
+  maximumNumberOfPenalty: 0,
+  setProfileImageURL: (profileImageURL: string) => set({ profileImageURL }),
+  setName: (name: string) => set({ name }),
+  setDescription: (description: string) => set({ description }),
+  setTags: (tags: string[]) => set({ tags }),
+  setNumberOfMembers: (numberOfMembers: number) => set({ numberOfMembers }),
+  setGifticonID: (gifticonID: string) => set({ gifticonID }),
+  setMaximumNumberOfPenalty: (maximumNumberOfPenalty: number) =>
+    set({ maximumNumberOfPenalty })
+}));
+
+export default useNewGroupInformationStore;

--- a/yarn.lock
+++ b/yarn.lock
@@ -11179,6 +11179,13 @@ yocto-queue@^0.1.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
+zustand@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/zustand/-/zustand-4.1.2.tgz#4912b24741662d8a84ed1cb52198471cb369c4b6"
+  integrity sha512-gcRaKchcxFPbImrBb/BKgujOhHhik9YhVpIeP87ETT7uokEe2Szu7KkuZ9ghjtD+/KKkcrRNktR2AiLXPIbKIQ==
+  dependencies:
+    use-sync-external-store "1.2.0"
+
 zwitch@^1.0.0:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/zwitch/-/zwitch-1.0.5.tgz#d11d7381ffed16b742f6af7b3f223d5cd9fe9920"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9801,6 +9801,11 @@ signal-exit@^3.0.0, signal-exit@^3.0.2, signal-exit@^3.0.3:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
 
+simple-zustand-devtools@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/simple-zustand-devtools/-/simple-zustand-devtools-1.1.0.tgz#bb080b30c9930d2997f33881f63d47405226fd7f"
+  integrity sha512-Axfcfr9L3YL3kto7aschCQLY2VUlXXMnIVtaTe9Y0qWbNmPsX/y7KsNprmxBZoB0pww5ZGs1u/ohcrvQ3tE6jA==
+
 sisteransi@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.5.tgz#134d681297756437cc05ca01370d3a7a571075ed"


### PR DESCRIPTION
resolved #158

모임 만들기 과정에서 기본 정보 입력 후 전역 상태에 입력값 저장, 두 번째 입력 후 저장되었던 입력값을 쓸 수 있게 했습니다.