### PR TITLE
모임 설정 페이지 중 '모임 정보' 탭 마크업

### DIFF
--- a/src/components/molecules/SegmentTab/index.tsx
+++ b/src/components/molecules/SegmentTab/index.tsx
@@ -21,14 +21,15 @@ const Container = styled.div`
   background-color: ${colors.grayScale.gray01};
 `;
 
-const TabContainer = styled.div`
+const TabContainer = styled.div<{ isSelected: boolean }>`
   display: flex;
   align-items: center;
   justify-content: center;
   width: calc((100% - 8px) / 2);
   padding: 6px 0;
   border-radius: 8px;
-  background-color: ${colors.grayScale.white};
+  background-color: ${({ isSelected }) =>
+    isSelected ? colors.grayScale.white : 'transparent'};
 `;
 
 const TabStyled = styled(Tab)`
@@ -48,7 +49,7 @@ const SegmentTab = ({
 }: Props) => {
   return (
     <Container className={className}>
-      <TabContainer>
+      <TabContainer isSelected={value === 'left'}>
         <TabStyled isSelected={value === 'left'} htmlFor="tab1">
           {leftTabLabel}
         </TabStyled>
@@ -61,7 +62,7 @@ const SegmentTab = ({
         value="left"
         onChange={onChange}
       />
-      <TabContainer>
+      <TabContainer isSelected={value === 'right'}>
         <TabStyled isSelected={value === 'right'} htmlFor="tab2">
           {rightTabLabel}
         </TabStyled>

--- a/src/pages/group/setting.tsx
+++ b/src/pages/group/setting.tsx
@@ -1,4 +1,101 @@
+import styled from '@emotion/styled';
+
+import { Button } from '../../components/atoms';
+import {
+  ImageUploadInput,
+  SegmentTab,
+  TagInput,
+  TextArea,
+  TextInput,
+  TopNavBar
+} from '../../components/molecules';
+import ButtonFooter from '../../components/molecules/ButtonFooter';
+import colors from '../../styles/colors';
+
+const Background = styled.div`
+  box-sizing: border-box;
+  min-height: 100vh;
+  padding-bottom: 84px;
+  background-color: ${colors.grayScale.gray01};
+`;
+
+const TabContainer = styled.div`
+  padding: 12px 20px;
+  background-color: ${colors.grayScale.white};
+`;
+
+const WhiteBox = styled.div`
+  padding: 20px;
+  background-color: ${colors.grayScale.white};
+
+  &:not(:nth-of-type(5)) {
+    margin-bottom: 16px;
+  }
+`;
+
+const TextAreaStyled = styled(TextArea)`
+  margin-top: 20px;
+`;
+
 const Setting = () => {
-  return <div>Setting</div>;
+  return (
+    <Background>
+      <TopNavBar setting={false} backURL="./home" />
+      <TabContainer>
+        <SegmentTab
+          leftTabLabel="모임 정보"
+          rightTabLabel="구성원 관리"
+          value={'left'}
+          onChange={(e) => console.log(e)}
+        />
+      </TabContainer>
+      <ImageUploadInput
+        profileImage={''}
+        onClickDeleteImage={() => console.log()}
+        onChangeImageFile={() => console.log()}
+      />
+      <WhiteBox>
+        <TextInput
+          value={''}
+          onChange={() => console.log()}
+          label="모임 이름"
+          placeholder="모임 이름을 입력해주세요."
+        />
+        <TextAreaStyled
+          value={''}
+          onChange={() => console.log()}
+          label="모임 내용"
+          placeholder="예시) 저희는 oo을 하는 모임입니다."
+        />
+      </WhiteBox>
+      <WhiteBox>
+        <TagInput
+          label="태그"
+          tagList={[]}
+          isTagExists={false}
+          addTag={() => console.log()}
+          deleteTag={() => console.log()}
+        />
+      </WhiteBox>
+      <WhiteBox>
+        <Button
+          size="medium"
+          disabled={false}
+          color="gray"
+          onClick={() => console.log()}
+        >
+          모임 끝내기
+        </Button>
+      </WhiteBox>
+      <ButtonFooter
+        disabled={false}
+        onClick={function (): void {
+          throw new Error('Function not implemented.');
+        }}
+      >
+        모임 정보 수정하기
+      </ButtonFooter>
+    </Background>
+  );
 };
 export default Setting;


### PR DESCRIPTION
resolved #154

- 모임 홈에서 오른쪽 위에 있는 설정 버튼을 누르면 이동하는 설정 페이지를 마크업했습니다.
- 모임 설정 페이지 마크업 중 `SegmentTab`에서 선택되지 않은 탭의 배경색이 투명해지도록 수정하였습니다.
- 인풋과 관련된 기능은 추후 구현할 예정입니다.
- '모임 끝내기' 혹은 '모임 나가기' 버튼의 경우 빨간색 계열로 다시 디자인해달라고 디자이너분께 요청한 상태입니다.

<img width="387" alt="image" src="https://user-images.githubusercontent.com/71015915/196759005-1cd467fd-251d-4def-b441-26cb7fb5d262.png">
