### PR TITLE
카카오 로그인 대기 화면에서 로딩 스피너 보여주기

### DIFF
--- a/src/components/atoms/Spinner/Spinner.stories.tsx
+++ b/src/components/atoms/Spinner/Spinner.stories.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import Spinner from './index';
+
+export default {
+  title: 'atoms/Spinner',
+  component: Spinner
+} as ComponentMeta<typeof Spinner>;
+
+export const Primary: ComponentStory<typeof Spinner> = () => <Spinner />;

--- a/src/components/atoms/Spinner/index.tsx
+++ b/src/components/atoms/Spinner/index.tsx
@@ -1,5 +1,7 @@
 import styled from '@emotion/styled';
 
+import colors from '../../../styles/colors';
+
 type Props = {
   className?: string;
 };
@@ -16,7 +18,7 @@ const ThreeDots = styled.div`
     width: 13px;
     height: 13px;
     border-radius: 50%;
-    background: #fff;
+    background: ${colors.mainColor.purple};
     animation-timing-function: cubic-bezier(0, 1, 1, 0);
   }
   & div:nth-child(1) {

--- a/src/components/atoms/Spinner/index.tsx
+++ b/src/components/atoms/Spinner/index.tsx
@@ -1,0 +1,75 @@
+import styled from '@emotion/styled';
+
+type Props = {
+  className?: string;
+};
+
+const ThreeDots = styled.div`
+  display: inline-block;
+  position: relative;
+  width: 80px;
+  height: 80px;
+
+  & div {
+    position: absolute;
+    top: 33px;
+    width: 13px;
+    height: 13px;
+    border-radius: 50%;
+    background: #fff;
+    animation-timing-function: cubic-bezier(0, 1, 1, 0);
+  }
+  & div:nth-child(1) {
+    left: 8px;
+    animation: lds-ellipsis1 0.6s infinite;
+  }
+  & div:nth-child(2) {
+    left: 8px;
+    animation: lds-ellipsis2 0.6s infinite;
+  }
+  & div:nth-child(3) {
+    left: 32px;
+    animation: lds-ellipsis2 0.6s infinite;
+  }
+  & div:nth-child(4) {
+    left: 56px;
+    animation: lds-ellipsis3 0.6s infinite;
+  }
+  @keyframes lds-ellipsis1 {
+    0% {
+      transform: scale(0);
+    }
+    100% {
+      transform: scale(1);
+    }
+  }
+  @keyframes lds-ellipsis3 {
+    0% {
+      transform: scale(1);
+    }
+    100% {
+      transform: scale(0);
+    }
+  }
+  @keyframes lds-ellipsis2 {
+    0% {
+      transform: translate(0, 0);
+    }
+    100% {
+      transform: translate(24px, 0);
+    }
+  }
+`;
+
+const Spinner = ({ className }: Props) => {
+  return (
+    <ThreeDots className={className}>
+      <div></div>
+      <div></div>
+      <div></div>
+      <div></div>
+    </ThreeDots>
+  );
+};
+
+export default Spinner;

--- a/src/components/atoms/index.ts
+++ b/src/components/atoms/index.ts
@@ -5,6 +5,7 @@ export { default as IconButton } from './IconButton';
 export { default as KakaoLoginButton } from './KakaoLoginButton';
 export { default as Label } from './Label';
 export { default as Logo } from './Logo';
+export { default as Spinner } from './Spinner';
 export { default as Tab } from './Tab';
 export { default as Tag } from './Tag';
 export { default as TagMaker } from './TagMaker';

--- a/src/pages/auth/kakao.tsx
+++ b/src/pages/auth/kakao.tsx
@@ -1,7 +1,16 @@
 import { useEffect } from 'react';
 import Router from 'next/router';
+import styled from '@emotion/styled';
 
 import loginWithKakao from '../../api/loginWithKakao';
+import { Spinner } from '../../components/atoms';
+
+const Container = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+`;
 
 const Kakao = () => {
   useEffect(() => {
@@ -17,7 +26,11 @@ const Kakao = () => {
     login();
   }, []);
 
-  return <div>로그인중</div>;
+  return (
+    <Container>
+      <Spinner />
+    </Container>
+  );
 };
 
 export default Kakao;


### PR DESCRIPTION
resolved #157

- 구글링으로 적당한 로딩 스피너 CSS를 복사해 `Spinner` 컴포넌트로 만들었습니다.
- 이 컴포넌트를 `/auth/kakao` 페이지에서 보여주었습니다.

<img width="398" alt="image" src="https://user-images.githubusercontent.com/71015915/196774195-cfc62b9b-294d-42eb-9114-e30584af4f46.png">
