### PR TITLE
그룹 구성원 관리 탭 마크업

### DIFF
--- a/src/pages/group/home.tsx
+++ b/src/pages/group/home.tsx
@@ -166,7 +166,11 @@ const Card = styled.div`
 const Home = () => {
   return (
     <Background>
-      <TopNavBar backURL="/home" setting={true} settingURL="./setting" />
+      <TopNavBar
+        backURL="/home"
+        setting={true}
+        settingURL="./setting/group-information"
+      />
       <GroupName>그룹 이름</GroupName>
       <NavigationBox>
         <Tab isSelected={true} htmlFor="">

--- a/src/pages/group/setting/group-information.tsx
+++ b/src/pages/group/setting/group-information.tsx
@@ -1,6 +1,8 @@
+import { ChangeEventHandler } from 'react';
+import Router from 'next/router';
 import styled from '@emotion/styled';
 
-import { Button } from '../../components/atoms';
+import { Button } from '../../../components/atoms';
 import {
   ImageUploadInput,
   SegmentTab,
@@ -8,9 +10,9 @@ import {
   TextArea,
   TextInput,
   TopNavBar
-} from '../../components/molecules';
-import ButtonFooter from '../../components/molecules/ButtonFooter';
-import colors from '../../styles/colors';
+} from '../../../components/molecules';
+import ButtonFooter from '../../../components/molecules/ButtonFooter';
+import colors from '../../../styles/colors';
 
 const Background = styled.div`
   box-sizing: border-box;
@@ -37,16 +39,23 @@ const TextAreaStyled = styled(TextArea)`
   margin-top: 20px;
 `;
 
-const Setting = () => {
+const GroupInformation = () => {
+  const handleTabChange: ChangeEventHandler<HTMLInputElement> = ({
+    target: { value }
+  }) => {
+    if (value === 'left') return;
+    Router.push('./group-member');
+  };
+
   return (
     <Background>
-      <TopNavBar setting={false} backURL="./home" />
+      <TopNavBar setting={false} backURL="/group/home" />
       <TabContainer>
         <SegmentTab
           leftTabLabel="모임 정보"
           rightTabLabel="구성원 관리"
-          value={'left'}
-          onChange={(e) => console.log(e)}
+          value="left"
+          onChange={handleTabChange}
         />
       </TabContainer>
       <ImageUploadInput
@@ -98,4 +107,4 @@ const Setting = () => {
     </Background>
   );
 };
-export default Setting;
+export default GroupInformation;

--- a/src/pages/group/setting/group-member.tsx
+++ b/src/pages/group/setting/group-member.tsx
@@ -1,0 +1,95 @@
+import { ChangeEventHandler } from 'react';
+import Router from 'next/router';
+import styled from '@emotion/styled';
+
+import { DEMO_PROFILE_IMAGE_URL } from '../../../__mocks__';
+import { TextButton } from '../../../components/atoms';
+import MemberList from '../../../components/atoms/MemberList';
+import { SegmentTab, TopNavBar } from '../../../components/molecules';
+import colors from '../../../styles/colors';
+import { regular16, semiBold16 } from '../../../styles/typography';
+
+const Background = styled.div`
+  box-sizing: border-box;
+  min-height: 100vh;
+  padding-bottom: 84px;
+  background-color: ${colors.grayScale.gray01};
+`;
+
+const TabContainer = styled.div`
+  padding: 12px 20px;
+  background-color: ${colors.grayScale.white};
+`;
+
+const InviteCodeContainer = styled.div`
+  display: flex;
+  align-items: center;
+  padding: 16px 20px;
+  background-color: ${colors.grayScale.white};
+`;
+
+const CodeLabel = styled.span`
+  ${regular16}
+  margin-right: 12px;
+  color: ${colors.grayScale.gray04};
+`;
+
+const InviteCode = styled.strong`
+  ${semiBold16}
+  color: ${colors.grayScale.gray05};
+`;
+
+const InviteCodePasteButton = styled(TextButton)`
+  margin-left: auto;
+`;
+
+const WhiteBox = styled.div`
+  margin-top: 16px;
+  background-color: ${colors.grayScale.white};
+`;
+
+const GroupMember = () => {
+  const handleTabChange: ChangeEventHandler<HTMLInputElement> = ({
+    target: { value }
+  }) => {
+    if (value === 'right') return;
+    Router.push('./group-information');
+  };
+
+  return (
+    <Background>
+      <TopNavBar backURL="/group/home" setting={false} />
+      <TabContainer>
+        <SegmentTab
+          leftTabLabel="모임 정보"
+          rightTabLabel="구성원 관리"
+          value="right"
+          onChange={handleTabChange}
+        />
+      </TabContainer>
+      <InviteCodeContainer>
+        <CodeLabel>초대 코드</CodeLabel>
+        <InviteCode>233 221</InviteCode>
+        <InviteCodePasteButton
+          color="navy"
+          disabled={false}
+          onClick={function (): void {
+            throw new Error('Function not implemented.');
+          }}
+        >
+          초대 코드 복사하기
+        </InviteCodePasteButton>
+      </InviteCodeContainer>
+      <WhiteBox>
+        <MemberList src={DEMO_PROFILE_IMAGE_URL} name="구성원 이름" />
+        <MemberList src={DEMO_PROFILE_IMAGE_URL} name="구성원 이름" />
+        <MemberList src={DEMO_PROFILE_IMAGE_URL} name="구성원 이름" />
+        <MemberList src={DEMO_PROFILE_IMAGE_URL} name="구성원 이름" />
+        <MemberList src={DEMO_PROFILE_IMAGE_URL} name="구성원 이름" />
+        <MemberList src={DEMO_PROFILE_IMAGE_URL} name="구성원 이름" />
+      </WhiteBox>
+    </Background>
+  );
+};
+
+export default GroupMember;

--- a/src/pages/group/setting/group-member.tsx
+++ b/src/pages/group/setting/group-member.tsx
@@ -9,6 +9,46 @@ import { SegmentTab, TopNavBar } from '../../../components/molecules';
 import colors from '../../../styles/colors';
 import { regular16, semiBold16 } from '../../../styles/typography';
 
+const GROUP_MEMBERS_MOCK = [
+  {
+    id: 1,
+    src: DEMO_PROFILE_IMAGE_URL,
+    name: '구성원 이름'
+  },
+  {
+    id: 2,
+    src: DEMO_PROFILE_IMAGE_URL,
+    name: '구성원 이름'
+  },
+  {
+    id: 3,
+    src: DEMO_PROFILE_IMAGE_URL,
+    name: '구성원 이름'
+  },
+  {
+    id: 4,
+    src: DEMO_PROFILE_IMAGE_URL,
+    name: '구성원 이름'
+  },
+  {
+    id: 5,
+    src: DEMO_PROFILE_IMAGE_URL,
+    name: '구성원 이름'
+  },
+  {
+    id: 6,
+    src: DEMO_PROFILE_IMAGE_URL,
+    name: '구성원 이름'
+  },
+  {
+    id: 7,
+    src: DEMO_PROFILE_IMAGE_URL,
+    name: '구성원 이름'
+  }
+];
+
+const INVITE_CODE_MOCK = '122 321';
+
 const Background = styled.div`
   box-sizing: border-box;
   min-height: 100vh;
@@ -69,7 +109,7 @@ const GroupMember = () => {
       </TabContainer>
       <InviteCodeContainer>
         <CodeLabel>초대 코드</CodeLabel>
-        <InviteCode>233 221</InviteCode>
+        <InviteCode>{INVITE_CODE_MOCK}</InviteCode>
         <InviteCodePasteButton
           color="navy"
           disabled={false}
@@ -81,12 +121,9 @@ const GroupMember = () => {
         </InviteCodePasteButton>
       </InviteCodeContainer>
       <WhiteBox>
-        <MemberList src={DEMO_PROFILE_IMAGE_URL} name="구성원 이름" />
-        <MemberList src={DEMO_PROFILE_IMAGE_URL} name="구성원 이름" />
-        <MemberList src={DEMO_PROFILE_IMAGE_URL} name="구성원 이름" />
-        <MemberList src={DEMO_PROFILE_IMAGE_URL} name="구성원 이름" />
-        <MemberList src={DEMO_PROFILE_IMAGE_URL} name="구성원 이름" />
-        <MemberList src={DEMO_PROFILE_IMAGE_URL} name="구성원 이름" />
+        {GROUP_MEMBERS_MOCK.map(({ id, src, name }) => (
+          <MemberList key={id} {...{ src, name }} />
+        ))}
       </WhiteBox>
     </Background>
   );


### PR DESCRIPTION
resolved #170

- 그룹 구성원을 관리할 수 있는 탭을 마크업했습니다.
- 현재 목 데이터를 사용하여 구성원 및 초대 코드를 보여주고 있습니다.
- 구성원 아이템을 왼쪽으로 슬라이드 했을 때 강퇴 버튼이 나타나는 기능은 별도의 PR에서 구현할 예정입니다.

![image](https://user-images.githubusercontent.com/71015915/197526134-8c9550d1-997b-4d45-9576-be07a3cae992.png)
