### PR TITLE
그룹 페이지 헤더를 organism 컴포넌트로 만들기

### DIFF
--- a/src/components/atoms/Tab/index.tsx
+++ b/src/components/atoms/Tab/index.tsx
@@ -1,4 +1,5 @@
 import { ReactNode } from 'react';
+import Link from 'next/link';
 import styled from '@emotion/styled';
 
 import colors from '../../../styles/colors';
@@ -9,17 +10,24 @@ type Props = {
   isSelected: boolean;
   htmlFor: string;
   children: ReactNode;
+  href: string;
 };
 
-const Label = styled.label<Pick<Props, 'isSelected'>>`
+const TabLink = styled.a<Pick<Props, 'isSelected'>>`
   ${semiBold16}
-  text-align: center;
   color: ${({ isSelected }) =>
     isSelected ? colors.grayScale.gray05 : colors.grayScale.gray03};
+  text-decoration: none;
 `;
 
-const Tab = ({ className, isSelected, htmlFor, children }: Props) => {
-  return <Label {...{ className, isSelected, htmlFor }}>{children}</Label>;
+const Tab = ({ className, isSelected, htmlFor, children, href }: Props) => {
+  return (
+    <Link href={href} passHref>
+      <TabLink {...{ className, isSelected, htmlFor, href }}>
+        {children}
+      </TabLink>
+    </Link>
+  );
 };
 
 export default Tab;

--- a/src/components/organisms/GroupPageHeader/GroupPageHeader.stories.tsx
+++ b/src/components/organisms/GroupPageHeader/GroupPageHeader.stories.tsx
@@ -1,0 +1,12 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import GroupPageHeader from './index';
+
+export default {
+  title: 'organisms/GroupPageHeader',
+  component: GroupPageHeader
+} as ComponentMeta<typeof GroupPageHeader>;
+
+export const Primary: ComponentStory<typeof GroupPageHeader> = ({
+  groupName = '그룹 이름'
+}) => <GroupPageHeader groupName={groupName} />;

--- a/src/components/organisms/GroupPageHeader/index.tsx
+++ b/src/components/organisms/GroupPageHeader/index.tsx
@@ -1,0 +1,56 @@
+import styled from '@emotion/styled';
+
+import colors from '../../../styles/colors';
+import { semiBold20 } from '../../../styles/typography';
+import { Tab } from '../../atoms';
+import { TopNavBar } from '../../molecules';
+
+type Props = {
+  className?: string;
+  groupName: string;
+};
+
+const GroupName = styled.h1`
+  ${semiBold20}
+  display: block;
+  height: 50px;
+  padding-left: 20px;
+  background-color: ${colors.grayScale.white};
+  color: ${colors.grayScale.gray05};
+  line-height: 50px;
+`;
+
+const NavigationBox = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-around;
+  height: 56px;
+  border-bottom: 1px solid ${colors.grayScale.gray02};
+  background-color: ${colors.grayScale.white};
+`;
+
+const GroupPageHeader = ({ className, groupName }: Props) => {
+  return (
+    <div className={className}>
+      <TopNavBar
+        backURL="/home"
+        setting={true}
+        settingURL="./setting/information"
+      />
+      <GroupName>{groupName}</GroupName>
+      <NavigationBox>
+        <Tab isSelected={true} htmlFor="" href="">
+          홈
+        </Tab>
+        <Tab isSelected={false} htmlFor="" href="">
+          회의 시간
+        </Tab>
+        <Tab isSelected={false} htmlFor="" href="">
+          초대하기
+        </Tab>
+      </NavigationBox>
+    </div>
+  );
+};
+
+export default GroupPageHeader;

--- a/src/components/organisms/index.ts
+++ b/src/components/organisms/index.ts
@@ -1,0 +1,1 @@
+export { default as GroupPageHeader } from './GroupPageHeader';

--- a/src/pages/group/home.tsx
+++ b/src/pages/group/home.tsx
@@ -2,11 +2,13 @@ import { useRef } from 'react';
 import styled from '@emotion/styled';
 
 import { DEMO_PROFILE_IMAGE_URL } from '../../__mocks__';
-import { Avatar, Tab } from '../../components/atoms';
-import { TopNavBar } from '../../components/molecules';
+import { Avatar } from '../../components/atoms';
+import { GroupPageHeader } from '../../components/organisms';
 import { useAdjustNumberOfProfiles } from '../../hooks';
 import colors from '../../styles/colors';
 import { medium12, semiBold16, semiBold20 } from '../../styles/typography';
+
+const GROUP_NAME_MOCK = 'SW마에스트로 그룹';
 
 const MEETINGS = [
   {
@@ -127,25 +129,6 @@ const Background = styled.div`
   background-color: ${colors.grayScale.gray01};
 `;
 
-const GroupName = styled.h1`
-  ${semiBold20}
-  display: block;
-  height: 50px;
-  padding-left: 20px;
-  background-color: ${colors.grayScale.white};
-  color: ${colors.grayScale.gray05};
-  line-height: 50px;
-`;
-
-const NavigationBox = styled.div`
-  display: flex;
-  align-items: center;
-  justify-content: space-around;
-  height: 56px;
-  border-bottom: 1px solid ${colors.grayScale.gray02};
-  background-color: ${colors.grayScale.white};
-`;
-
 const CardBox = styled.div`
   padding: 16px 20px;
 `;
@@ -166,23 +149,7 @@ const Card = styled.div`
 const Home = () => {
   return (
     <Background>
-      <TopNavBar
-        backURL="/home"
-        setting={true}
-        settingURL="./setting/information"
-      />
-      <GroupName>그룹 이름</GroupName>
-      <NavigationBox>
-        <Tab isSelected={true} htmlFor="">
-          홈
-        </Tab>
-        <Tab isSelected={false} htmlFor="">
-          회의 시간
-        </Tab>
-        <Tab isSelected={false} htmlFor="">
-          초대하기
-        </Tab>
-      </NavigationBox>
+      <GroupPageHeader groupName={GROUP_NAME_MOCK} />
       <CardBox>
         <SubTitle>가까운 회의 일정</SubTitle>
         {MEETINGS.map(({ id, title, location, date, participants }) => (


### PR DESCRIPTION
resolved #176

그룹 페이지 헤더가 여러 페이지에서 재사용되므로 organism 컴포넌트로 만드는 작업을 했습니다.

<img width="811" alt="image" src="https://user-images.githubusercontent.com/71015915/197558402-bdc529e0-ddaf-4b0b-aa3c-98235d053da6.png">
