### PR TITLE
회의 시간 추천 페이지 마크업

### DIFF
--- a/src/components/atoms/SuggestionTimeList/SuggestionTimeList.stories.tsx
+++ b/src/components/atoms/SuggestionTimeList/SuggestionTimeList.stories.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import SuggestionTimeList from './index';
+
+export default {
+  title: 'atoms/SuggestionTimeList',
+  component: SuggestionTimeList
+} as ComponentMeta<typeof SuggestionTimeList>;
+
+export const Primary: ComponentStory<typeof SuggestionTimeList> = ({
+  date = '2022.09.01 (목)',
+  time = '오전 10:00 ~ 오후 11:00'
+}) => <SuggestionTimeList {...{ date, time }} />;

--- a/src/components/atoms/SuggestionTimeList/index.tsx
+++ b/src/components/atoms/SuggestionTimeList/index.tsx
@@ -1,0 +1,37 @@
+import styled from '@emotion/styled';
+
+import colors from '../../../styles/colors';
+import { regular16, semiBold16 } from '../../../styles/typography';
+
+type Props = {
+  className?: string;
+  date: string;
+  time: string;
+};
+
+const Container = styled.div`
+  padding: 16px 20px;
+  background-color: ${colors.grayScale.white};
+`;
+
+const Date = styled.span`
+  ${semiBold16}
+  color: ${colors.mainColor.navy};
+`;
+
+const Time = styled.span`
+  ${regular16}
+  display: block;
+  color: ${colors.grayScale.gray03};
+`;
+
+const SuggestionTimeList = ({ className, date, time }: Props) => {
+  return (
+    <Container className={className}>
+      <Date>{date}</Date>
+      <Time>{time}</Time>
+    </Container>
+  );
+};
+
+export default SuggestionTimeList;

--- a/src/components/atoms/index.ts
+++ b/src/components/atoms/index.ts
@@ -6,6 +6,7 @@ export { default as KakaoLoginButton } from './KakaoLoginButton';
 export { default as Label } from './Label';
 export { default as Logo } from './Logo';
 export { default as Spinner } from './Spinner';
+export { default as SuggestionTimeList } from './SuggestionTimeList';
 export { default as Tab } from './Tab';
 export { default as Tag } from './Tag';
 export { default as TagMaker } from './TagMaker';

--- a/src/pages/group/meeting/index.tsx
+++ b/src/pages/group/meeting/index.tsx
@@ -1,9 +1,13 @@
+import Router from 'next/router';
+
 import { GROUP_NAME_MOCK, MEETINGS_MOCK } from '../../../__mocks__';
 import { MeetingCard } from '../../../components/molecules';
 import ButtonFooter from '../../../components/molecules/ButtonFooter';
 import { GroupPage } from '../../../components/templates';
 
 const Meeting = () => {
+  const handleClickFooterButton = () => Router.push('./meeting/suggestion');
+
   return (
     <>
       <GroupPage groupName={GROUP_NAME_MOCK} selectedTabIndex={1}>
@@ -14,12 +18,7 @@ const Meeting = () => {
             editLink="./meeting"
           />
         ))}
-        <ButtonFooter
-          disabled={false}
-          onClick={function (): void {
-            throw new Error('Function not implemented.');
-          }}
-        >
+        <ButtonFooter disabled={false} onClick={handleClickFooterButton}>
           회의 만들기
         </ButtonFooter>
       </GroupPage>

--- a/src/pages/group/meeting/suggestion.tsx
+++ b/src/pages/group/meeting/suggestion.tsx
@@ -1,0 +1,89 @@
+import styled from '@emotion/styled';
+
+import { Button, SuggestionTimeList } from '../../../components/atoms';
+import { TopNavBar } from '../../../components/molecules';
+import colors from '../../../styles/colors';
+import { semiBold16, semiBold20 } from '../../../styles/typography';
+
+const SUGGESTION_TIME_MOCK = [
+  {
+    date: '2022.09.01 (목)',
+    time: '오전 10:00 ~ 오후 12:00'
+  },
+  {
+    date: '2022.09.02 (목)',
+    time: '오전 10:00 ~ 오후 12:00'
+  },
+  {
+    date: '2022.09.03 (목)',
+    time: '오전 10:00 ~ 오후 12:00'
+  },
+  {
+    date: '2022.09.04 (목)',
+    time: '오전 10:00 ~ 오후 12:00'
+  },
+  {
+    date: '2022.09.05 (목)',
+    time: '오전 10:00 ~ 오후 12:00'
+  },
+  {
+    date: '2022.09.06 (목)',
+    time: '오전 10:00 ~ 오후 12:00'
+  },
+  {
+    date: '2022.09.07 (목)',
+    time: '오전 10:00 ~ 오후 12:00'
+  }
+];
+
+const TitleContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
+  padding: 20px 20px 16px;
+`;
+
+const Title = styled.h1`
+  display: block;
+  padding: 7px 0;
+  ${semiBold20}
+  color: ${colors.grayScale.gray05};
+`;
+
+const EditLink = styled.a`
+  display: block;
+  padding: 10px 12px;
+  ${semiBold16}
+  color: ${colors.grayScale.gray04};
+`;
+
+const AddTimeButton = styled(Button)`
+  margin: 24px auto 0;
+`;
+
+const Suggestion = () => {
+  return (
+    <>
+      <TopNavBar setting={false} backURL="../" />
+      <TitleContainer>
+        <Title>회의가 가능한 날들이에요.</Title>
+        <EditLink>수정</EditLink>
+      </TitleContainer>
+      {SUGGESTION_TIME_MOCK.map(({ date, time }) => (
+        <SuggestionTimeList key={date + time} {...{ date, time }} />
+      ))}
+      <AddTimeButton
+        size="large"
+        width="250px"
+        disabled={false}
+        color="purple"
+        onClick={function (): void {
+          throw new Error('Function not implemented.');
+        }}
+      >
+        시간 직접 추가하기
+      </AddTimeButton>
+    </>
+  );
+};
+
+export default Suggestion;


### PR DESCRIPTION
resolved #181

- 추천 시간 목록에 쓰이는 컴포넌트를 SuggestionTimeList 컴포넌트로 만들어 atoms에 추가했습니다. 추천 시간 설정 페이지에서 또 쓰이기 때문입니다.
- 위의 SuggestionTimeList 컴포넌트를 사용하여 회의 시간 추천 페이지를 마크업했습니다.

<img width="381" alt="image" src="https://user-images.githubusercontent.com/71015915/197773996-15b2a469-a919-49c6-8143-1b3c1fb29b42.png">
