### PR TITLE
추천 시간이 없을 때 보여주는 페이지 마크업

### DIFF
--- a/src/pages/group/meeting/suggestion.tsx
+++ b/src/pages/group/meeting/suggestion.tsx
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-import { Button, SuggestionTimeList } from '../../../components/atoms';
+import { Button, Logo, SuggestionTimeList } from '../../../components/atoms';
 import { TopNavBar } from '../../../components/molecules';
 import colors from '../../../styles/colors';
 import { semiBold16, semiBold20 } from '../../../styles/typography';
@@ -49,6 +49,12 @@ const Title = styled.h1`
   color: ${colors.grayScale.gray05};
 `;
 
+const SuggestionTimeListStyled = styled(SuggestionTimeList)`
+  &:last-of-type {
+    margin-bottom: 24px;
+  }
+`;
+
 const EditLink = styled.a`
   display: block;
   padding: 10px 12px;
@@ -56,21 +62,42 @@ const EditLink = styled.a`
   color: ${colors.grayScale.gray04};
 `;
 
+const EmptyLogo = styled(Logo)`
+  margin: 140px auto 20px;
+`;
+
+const EmptyDescription = styled.span`
+  ${semiBold20}
+  display: block;
+  margin-bottom: 36px;
+  color: ${colors.grayScale.gray04};
+  text-align: center;
+`;
+
 const AddTimeButton = styled(Button)`
-  margin: 24px auto 0;
+  margin: 0 auto;
 `;
 
 const Suggestion = () => {
   return (
     <>
-      <TopNavBar setting={false} backURL="../" />
-      <TitleContainer>
-        <Title>회의가 가능한 날들이에요.</Title>
-        <EditLink>수정</EditLink>
-      </TitleContainer>
-      {SUGGESTION_TIME_MOCK.map(({ date, time }) => (
-        <SuggestionTimeList key={date + time} {...{ date, time }} />
-      ))}
+      <TopNavBar setting={false} backURL="./" />
+      {SUGGESTION_TIME_MOCK.length ? (
+        <>
+          <TitleContainer>
+            <Title>회의가 가능한 날들이에요.</Title>
+            <EditLink>수정</EditLink>
+          </TitleContainer>
+          {SUGGESTION_TIME_MOCK.map(({ date, time }) => (
+            <SuggestionTimeListStyled key={date + time} {...{ date, time }} />
+          ))}
+        </>
+      ) : (
+        <>
+          <EmptyLogo />
+          <EmptyDescription>추천할 수 있는 시간대가 없어요.</EmptyDescription>
+        </>
+      )}
       <AddTimeButton
         size="large"
         width="250px"


### PR DESCRIPTION
resolved #183

서버로부터 불러온 추천 시간 리스트가 비어있을 경우 사용자에게 추천 시간이 없다는 안내 페이지를 보여줍니다.

<img width="379" alt="image" src="https://user-images.githubusercontent.com/71015915/197961163-0db27c9b-d676-4700-80c4-abad7f523725.png">
