### PR TITLE
TimePicker 컴포넌트 마크업

### DIFF
--- a/src/components/molecules/TimePicker/TimePicker.stories.tsx
+++ b/src/components/molecules/TimePicker/TimePicker.stories.tsx
@@ -1,0 +1,55 @@
+import React, { ChangeEvent, useEffect, useState } from 'react';
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import TimerPicker from './index';
+
+export default {
+  title: 'molecules/TimerPicker',
+  component: TimerPicker
+} as ComponentMeta<typeof TimerPicker>;
+
+export const Primary: ComponentStory<typeof TimerPicker> = ({
+  allDayOption
+}) => {
+  const tzoffset = new Date().getTimezoneOffset() * 60000;
+  const ISOString = new Date(Date.now() - tzoffset).toISOString();
+  const todayDatetime = ISOString.slice(0, 16);
+  const [isToggleOn, setIsToggleOn] = useState(false);
+  const [startDatetime, setStartDatetime] = useState(todayDatetime);
+  const [endDatetime, setEndDatetime] = useState(todayDatetime);
+
+  useEffect(() => {
+    if (isToggleOn) {
+      setStartDatetime((pre) => pre.slice(0, 10));
+      setEndDatetime((pre) => pre.slice(0, 10));
+      return;
+    }
+    if (startDatetime.length <= 10) setStartDatetime((pre) => pre + 'T00:00');
+    if (endDatetime.length <= 10) setEndDatetime((pre) => pre + 'T00:00');
+    // useEffect 내에서 startDatetime과 endDatetime을 사용하고 있지만 이 effect는 오직 isToggleOn에 의해서만 실행되어야 합니다.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isToggleOn]);
+
+  const handleClickToggle = () => setIsToggleOn((pre) => !pre);
+
+  const handleChangeDatetime = (
+    { target: { value } }: ChangeEvent<HTMLInputElement>,
+    target: 'start' | 'end'
+  ) => {
+    if (target === 'start') {
+      setStartDatetime(value);
+      return;
+    }
+    setEndDatetime(value);
+  };
+
+  return (
+    <TimerPicker
+      allDayOption={allDayOption}
+      onClickToggle={handleClickToggle}
+      onChangeStartDatetime={(event) => handleChangeDatetime(event, 'start')}
+      onChangeEndDatetime={(event) => handleChangeDatetime(event, 'end')}
+      {...{ isToggleOn, startDatetime, endDatetime }}
+    />
+  );
+};

--- a/src/components/molecules/TimePicker/index.tsx
+++ b/src/components/molecules/TimePicker/index.tsx
@@ -1,0 +1,106 @@
+import { ChangeEventHandler } from 'react';
+import styled from '@emotion/styled';
+
+import colors from '../../../styles/colors';
+import { regular16, semiBold16 } from '../../../styles/typography';
+import { Toggle } from '../../atoms';
+
+const TimeContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
+  padding: 16px 20px;
+  background-color: ${colors.grayScale.white};
+`;
+
+const Label = styled.span`
+  ${semiBold16}
+  color: ${colors.grayScale.gray04};
+`;
+
+const DatetimeInput = styled.input`
+  ${regular16}
+  border: none;
+  color: ${colors.grayScale.gray04};
+  background-color: ${colors.grayScale.white};
+
+  &:focus {
+    outline: none;
+    // 안드로이드 크롬에서 datetime-locale input 클릭 시 테두리 생기는 것 방지.
+  }
+`;
+
+type TimeBarProps = {
+  isAllDay: boolean;
+  label: string;
+  datetime: string;
+  onChange: ChangeEventHandler<HTMLInputElement>;
+};
+
+const TimeBar = ({ isAllDay, label, datetime, onChange }: TimeBarProps) => {
+  return (
+    <>
+      <TimeContainer>
+        <Label>{label}</Label>
+        <DatetimeInput
+          type={isAllDay ? 'date' : 'datetime-local'}
+          value={datetime}
+          onChange={onChange}
+        />
+      </TimeContainer>
+    </>
+  );
+};
+
+type DefaultProps = {
+  className?: string;
+  startDatetime: string;
+  endDatetime: string;
+  onChangeStartDatetime: ChangeEventHandler<HTMLInputElement>;
+  onChangeEndDatetime: ChangeEventHandler<HTMLInputElement>;
+};
+
+type OnlyTimePickerProps = {
+  allDayOption: false;
+} & DefaultProps;
+
+type AllDayOptionProps = {
+  allDayOption: true;
+  isToggleOn: boolean;
+  onClickToggle: () => void;
+} & DefaultProps;
+
+type Props = OnlyTimePickerProps | AllDayOptionProps;
+
+const TimePicker = ({
+  className,
+  startDatetime,
+  endDatetime,
+  onChangeStartDatetime,
+  onChangeEndDatetime,
+  ...props
+}: Props) => {
+  return (
+    <>
+      {props.allDayOption && (
+        <TimeContainer className={className}>
+          <Label>하루 종일</Label>
+          <Toggle isOn={props.isToggleOn} onClick={props.onClickToggle} />
+        </TimeContainer>
+      )}
+      <TimeBar
+        isAllDay={props.allDayOption ? props.isToggleOn : false}
+        label="시작"
+        datetime={startDatetime}
+        onChange={onChangeStartDatetime}
+      />
+      <TimeBar
+        isAllDay={props.allDayOption ? props.isToggleOn : false}
+        label="끝"
+        datetime={endDatetime}
+        onChange={onChangeEndDatetime}
+      />
+    </>
+  );
+};
+
+export default TimePicker;


### PR DESCRIPTION
resolved #186

- TimePicker 컴포넌트를 마크업했습니다.
- OS에서 제공하는 기본 날짜 선택창을 사용하기 위해 `input` 태그를 숨기고 사용자가 선택한 시간을 다른 태그에 스타일링해서 보여줄 계획이었습니다.
- 하지만 다른 어떤 방법을 써도 기본 `input` 태그를 통해서만 날짜 선택창을 띄울 수 있는 브라우저 환경이 있어 불가피하게 허용되는 범위 내에서 `input` 태그 자체를 스타일링하게 되었습니다.
- 날짜 및 시간 선택창을 직접 구현하는 방법도 있으나, 개발 일정상 직접 구현은 나중으로 미루겠습니다.

![image](https://user-images.githubusercontent.com/71015915/198085263-79cbc411-baa8-4971-a2df-14156cf0a72b.png)
![image](https://user-images.githubusercontent.com/71015915/198085313-4f1a3a83-b88a-4d70-a6af-23d5de5015d8.png)
![image](https://user-images.githubusercontent.com/71015915/198085477-9fa87bc8-f7d0-4c62-8bae-87f9a2d24d3e.png)

![image](https://user-images.githubusercontent.com/71015915/198085410-197fa613-d474-45bf-a7da-055bce353334.png)
