### PR TITLE
회의 불가능 시간 설정 페이지 마크업

### DIFF
--- a/src/components/molecules/TimePicker/TimePicker.stories.tsx
+++ b/src/components/molecules/TimePicker/TimePicker.stories.tsx
@@ -1,6 +1,7 @@
-import React, { ChangeEvent, useEffect, useState } from 'react';
+import React from 'react';
 import { ComponentMeta, ComponentStory } from '@storybook/react';
 
+import { UseDatetimePicker } from '../../../hooks';
 import TimerPicker from './index';
 
 export default {
@@ -11,44 +12,21 @@ export default {
 export const Primary: ComponentStory<typeof TimerPicker> = ({
   allDayOption
 }) => {
-  const tzoffset = new Date().getTimezoneOffset() * 60000;
-  const ISOString = new Date(Date.now() - tzoffset).toISOString();
-  const todayDatetime = ISOString.slice(0, 16);
-  const [isToggleOn, setIsToggleOn] = useState(false);
-  const [startDatetime, setStartDatetime] = useState(todayDatetime);
-  const [endDatetime, setEndDatetime] = useState(todayDatetime);
-
-  useEffect(() => {
-    if (isToggleOn) {
-      setStartDatetime((pre) => pre.slice(0, 10));
-      setEndDatetime((pre) => pre.slice(0, 10));
-      return;
-    }
-    if (startDatetime.length <= 10) setStartDatetime((pre) => pre + 'T00:00');
-    if (endDatetime.length <= 10) setEndDatetime((pre) => pre + 'T00:00');
-    // useEffect 내에서 startDatetime과 endDatetime을 사용하고 있지만 이 effect는 오직 isToggleOn에 의해서만 실행되어야 합니다.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isToggleOn]);
-
-  const handleClickToggle = () => setIsToggleOn((pre) => !pre);
-
-  const handleChangeDatetime = (
-    { target: { value } }: ChangeEvent<HTMLInputElement>,
-    target: 'start' | 'end'
-  ) => {
-    if (target === 'start') {
-      setStartDatetime(value);
-      return;
-    }
-    setEndDatetime(value);
-  };
+  const {
+    startDatetime,
+    endDatetime,
+    handleChangeEndDatetime,
+    handleChangeStartDatetime,
+    isToggleOn,
+    handleClickToggle
+  } = UseDatetimePicker();
 
   return (
     <TimerPicker
       allDayOption={allDayOption}
       onClickToggle={handleClickToggle}
-      onChangeStartDatetime={(event) => handleChangeDatetime(event, 'start')}
-      onChangeEndDatetime={(event) => handleChangeDatetime(event, 'end')}
+      onChangeStartDatetime={handleChangeStartDatetime}
+      onChangeEndDatetime={handleChangeEndDatetime}
       {...{ isToggleOn, startDatetime, endDatetime }}
     />
   );

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,3 +1,4 @@
 export { default as useAdjustNumberOfProfiles } from './useAdjustNumberOfProfiles';
 export { default as useCoords } from './useCoords';
+export { default as UseDatetimePicker } from './useDatetimePicker';
 export { default as useKakaoMaps } from './useKakaoMaps';

--- a/src/hooks/useDatetimePicker.ts
+++ b/src/hooks/useDatetimePicker.ts
@@ -1,0 +1,68 @@
+import { ChangeEvent, ChangeEventHandler, useEffect, useState } from 'react';
+
+const MILLISECOND_SCALING_VALUE = 60000;
+const DATETIME_START_INDEX = 0;
+const DATETIME_END_INDEX = 16;
+const DATE_START_INDEX = 0;
+const DATE_END_INDEX = 10;
+const DEFAULT_ISO_TIME_VALUE = 'T00:00';
+
+type TargetDatetime = 'start' | 'end';
+
+const UseDatetimePicker = () => {
+  const tzoffset = new Date().getTimezoneOffset() * MILLISECOND_SCALING_VALUE;
+  const ISOString = new Date(Date.now() - tzoffset).toISOString();
+  const todayDatetime = ISOString.slice(
+    DATETIME_START_INDEX,
+    DATETIME_END_INDEX
+  );
+  const [isToggleOn, setIsToggleOn] = useState(false);
+  const [startDatetime, setStartDatetime] = useState(todayDatetime);
+  const [endDatetime, setEndDatetime] = useState(todayDatetime);
+
+  useEffect(() => {
+    if (isToggleOn) {
+      setStartDatetime((pre) => pre.slice(DATE_START_INDEX, DATE_END_INDEX));
+      setEndDatetime((pre) => pre.slice(DATE_START_INDEX, DATE_END_INDEX));
+      return;
+    }
+    if (startDatetime.length <= DATE_END_INDEX)
+      setStartDatetime((pre) => pre + DEFAULT_ISO_TIME_VALUE);
+    if (endDatetime.length <= DATE_END_INDEX)
+      setEndDatetime((pre) => pre + DEFAULT_ISO_TIME_VALUE);
+    // useEffect 내에서 startDatetime과 endDatetime을 사용하고 있지만 이 effect는 오직 isToggleOn에 의해서만 실행되어야 합니다.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isToggleOn]);
+
+  const handleChangeDatetime = (
+    { target: { value } }: ChangeEvent<HTMLInputElement>,
+    target: TargetDatetime
+  ) => {
+    if (target === 'start') {
+      setStartDatetime(value);
+      return;
+    }
+    setEndDatetime(value);
+  };
+
+  const handleChangeStartDatetime: ChangeEventHandler<HTMLInputElement> = (
+    event
+  ) => handleChangeDatetime(event, 'start');
+
+  const handleChangeEndDatetime: ChangeEventHandler<HTMLInputElement> = (
+    event
+  ) => handleChangeDatetime(event, 'end');
+
+  const handleClickToggle = () => setIsToggleOn((pre) => !pre);
+
+  return {
+    startDatetime,
+    endDatetime,
+    handleChangeStartDatetime,
+    handleChangeEndDatetime,
+    isToggleOn,
+    handleClickToggle
+  };
+};
+
+export default UseDatetimePicker;

--- a/src/pages/group/meeting/suggestion/edit.tsx
+++ b/src/pages/group/meeting/suggestion/edit.tsx
@@ -1,0 +1,108 @@
+import styled from '@emotion/styled';
+
+import { Button, SuggestionTimeList } from '../../../../components/atoms';
+import { TopNavBar } from '../../../../components/molecules';
+import TimePicker from '../../../../components/molecules/TimePicker';
+import { UseDatetimePicker } from '../../../../hooks';
+import colors from '../../../../styles/colors';
+import { medium12, semiBold20 } from '../../../../styles/typography';
+
+const EXCEPTION_TIME_MOCK = [
+  {
+    date: '2022.09.01 (목)',
+    time: '오전 10:00 ~ 오후 11:00'
+  },
+  {
+    date: '2022.09.02 (목)',
+    time: '오전 10:00 ~ 오후 11:00'
+  },
+  {
+    date: '2022.09.03 (목)',
+    time: '오전 10:00 ~ 오후 11:00'
+  },
+  {
+    date: '2022.09.04 (목)',
+    time: '오전 10:00 ~ 오후 11:00'
+  },
+  {
+    date: '2022.09.05 (목)',
+    time: '오전 10:00 ~ 오후 11:00'
+  },
+  {
+    date: '2022.09.06 (목)',
+    time: '오전 10:00 ~ 오후 11:00'
+  }
+];
+
+const Background = styled.div`
+  min-height: 100vh;
+  background-color: ${colors.grayScale.gray01};
+`;
+
+const WhiteBox = styled.div`
+  padding: 20px;
+  background-color: ${colors.grayScale.white};
+`;
+
+const Title = styled.h1`
+  ${semiBold20};
+  display: block;
+  color: ${colors.grayScale.gray05};
+`;
+
+const AddButton = styled(Button)`
+  margin: 0 auto 12px;
+`;
+
+const Description = styled.span`
+  display: block;
+  ${medium12}
+  color: ${colors.grayScale.gray03};
+  text-align: center;
+`;
+
+const Edit = () => {
+  const {
+    startDatetime,
+    endDatetime,
+    handleChangeEndDatetime,
+    handleChangeStartDatetime
+  } = UseDatetimePicker();
+
+  const handleExcludedTimeSumbit = () =>
+    console.log(startDatetime, endDatetime);
+
+  return (
+    <Background>
+      <TopNavBar backURL="./" setting={false} />
+      <WhiteBox>
+        <Title>회의가 불가능한 시간들이애요.</Title>
+      </WhiteBox>
+      <TimePicker
+        allDayOption={false}
+        onChangeEndDatetime={handleChangeEndDatetime}
+        onChangeStartDatetime={handleChangeStartDatetime}
+        {...{ startDatetime, endDatetime }}
+      />
+      <WhiteBox>
+        <AddButton
+          color="purple"
+          width="250px"
+          size="medium"
+          disabled={false}
+          onClick={handleExcludedTimeSumbit}
+        >
+          제외할 시간 추가하기
+        </AddButton>
+        <Description>
+          추가시 아래에 회의 불가능한 시간으로 표시됩니다.
+        </Description>
+      </WhiteBox>
+      {EXCEPTION_TIME_MOCK.map(({ date, time }) => (
+        <SuggestionTimeList key={date + time} {...{ date, time }} />
+      ))}
+    </Background>
+  );
+};
+
+export default Edit;

--- a/src/pages/group/meeting/suggestion/index.tsx
+++ b/src/pages/group/meeting/suggestion/index.tsx
@@ -1,9 +1,10 @@
+import Link from 'next/link';
 import styled from '@emotion/styled';
 
-import { Button, Logo, SuggestionTimeList } from '../../../components/atoms';
-import { TopNavBar } from '../../../components/molecules';
-import colors from '../../../styles/colors';
-import { semiBold16, semiBold20 } from '../../../styles/typography';
+import { Button, Logo, SuggestionTimeList } from '../../../../components/atoms';
+import { TopNavBar } from '../../../../components/molecules';
+import colors from '../../../../styles/colors';
+import { semiBold16, semiBold20 } from '../../../../styles/typography';
 
 const SUGGESTION_TIME_MOCK = [
   {
@@ -56,10 +57,11 @@ const SuggestionTimeListStyled = styled(SuggestionTimeList)`
 `;
 
 const EditLink = styled.a`
+  ${semiBold16}
   display: block;
   padding: 10px 12px;
-  ${semiBold16}
   color: ${colors.grayScale.gray04};
+  text-decoration: none;
 `;
 
 const EmptyLogo = styled(Logo)`
@@ -86,7 +88,9 @@ const Suggestion = () => {
         <>
           <TitleContainer>
             <Title>회의가 가능한 날들이에요.</Title>
-            <EditLink>수정</EditLink>
+            <Link passHref href="./suggestion/edit">
+              <EditLink>수정</EditLink>
+            </Link>
           </TitleContainer>
           {SUGGESTION_TIME_MOCK.map(({ date, time }) => (
             <SuggestionTimeListStyled key={date + time} {...{ date, time }} />


### PR DESCRIPTION
resolved #185

- 추천 시간대에서 제외할 회의 불가능 시간을 추가할 수 있는 페이지를 마크업했습니다.
- 이미 추가된 제외 시간을 옆으로 슬라이드해 삭제할 수 있는 기능은 다른 PR에서 구현할 예정입니다.
- TimePicker 컴포넌트에서 필요한 프롭을 간편하게 사용할 수 있는 `useDatetimePicker` 훅을 만들었습니다. 또한 이 훅을 기존 TimePicker 스토리 파일에도 적용하였습니다.
- 사용자가 시간을 선택하고 추가 버튼을 누르면 해당 시간이 콘솔에 임시로 표시되도록 했습니다.

![image](https://user-images.githubusercontent.com/71015915/198289388-3e05007d-de55-4ec6-bc28-20296ae893c7.png)
