### PR TITLE
모임 생성 페이지 마크업

### DIFF
--- a/src/components/atoms/SuggestionTimeList/index.tsx
+++ b/src/components/atoms/SuggestionTimeList/index.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import styled from '@emotion/styled';
 
 import colors from '../../../styles/colors';
@@ -7,11 +8,14 @@ type Props = {
   className?: string;
   date: string;
   time: string;
+  href: string;
 };
 
-const Container = styled.div`
+const Container = styled.a`
+  display: block;
   padding: 16px 20px;
   background-color: ${colors.grayScale.white};
+  text-decoration: none;
 `;
 
 const Date = styled.span`
@@ -25,12 +29,14 @@ const Time = styled.span`
   color: ${colors.grayScale.gray03};
 `;
 
-const SuggestionTimeList = ({ className, date, time }: Props) => {
+const SuggestionTimeList = ({ className, date, time, href }: Props) => {
   return (
-    <Container className={className}>
-      <Date>{date}</Date>
-      <Time>{time}</Time>
-    </Container>
+    <Link passHref href={href}>
+      <Container className={className}>
+        <Date>{date}</Date>
+        <Time>{time}</Time>
+      </Container>
+    </Link>
   );
 };
 

--- a/src/components/atoms/SuggestionTimeList/index.tsx
+++ b/src/components/atoms/SuggestionTimeList/index.tsx
@@ -8,7 +8,7 @@ type Props = {
   className?: string;
   date: string;
   time: string;
-  href: string;
+  href?: string;
 };
 
 const Container = styled.a`
@@ -31,7 +31,7 @@ const Time = styled.span`
 
 const SuggestionTimeList = ({ className, date, time, href }: Props) => {
   return (
-    <Link passHref href={href}>
+    <Link passHref href={href || ''}>
       <Container className={className}>
         <Date>{date}</Date>
         <Time>{time}</Time>

--- a/src/components/molecules/MemberList/index.tsx
+++ b/src/components/molecules/MemberList/index.tsx
@@ -2,6 +2,7 @@ import styled from '@emotion/styled';
 
 import colors from '../../../styles/colors';
 import { regular16 } from '../../../styles/typography';
+import getRandomString from '../../../utils/getRandomString';
 import Avatar from '../../atoms/Avatar';
 import { CheckCircle } from '../../atoms/icons';
 
@@ -47,7 +48,7 @@ const CheckCircleStyled = styled(CheckCircle)`
 `;
 
 const MemberList = ({ className, src, name, ...props }: Props) => {
-  const inputId = `${name}-check-input`;
+  const inputId = `${name}-check-input-${getRandomString()}`;
 
   return (
     <>

--- a/src/pages/group/meeting/add.tsx
+++ b/src/pages/group/meeting/add.tsx
@@ -1,0 +1,5 @@
+const Add = () => {
+  return <div>회의 생성 페이지</div>;
+};
+
+export default Add;

--- a/src/pages/group/meeting/add.tsx
+++ b/src/pages/group/meeting/add.tsx
@@ -1,5 +1,189 @@
+import { ChangeEvent, ChangeEventHandler, useState } from 'react';
+import styled from '@emotion/styled';
+
+import { DEMO_PROFILE_IMAGE_URL } from '../../../__mocks__';
+import { TextButton, Toggle } from '../../../components/atoms';
+import {
+  MemberList,
+  TextInput,
+  TopNavBar
+} from '../../../components/molecules';
+import ButtonFooter from '../../../components/molecules/ButtonFooter';
+import TimePicker from '../../../components/molecules/TimePicker';
+import { UseDatetimePicker } from '../../../hooks';
+import colors from '../../../styles/colors';
+import { medium12, semiBold16, semiBold20 } from '../../../styles/typography';
+
+const MEMBERS_MOCK = [
+  {
+    id: 1,
+    src: DEMO_PROFILE_IMAGE_URL,
+    name: '구성원 이름'
+  },
+  {
+    id: 2,
+    src: DEMO_PROFILE_IMAGE_URL,
+    name: '구성원 이름'
+  },
+  {
+    id: 3,
+    src: DEMO_PROFILE_IMAGE_URL,
+    name: '구성원 이름'
+  },
+  {
+    id: 4,
+    src: DEMO_PROFILE_IMAGE_URL,
+    name: '구성원 이름'
+  },
+  {
+    id: 5,
+    src: DEMO_PROFILE_IMAGE_URL,
+    name: '구성원 이름'
+  }
+];
+
+const Background = styled.div`
+  box-sizing: border-box;
+  min-height: 100vh;
+  padding-bottom: 84px;
+  background-color: ${colors.grayScale.gray01};
+`;
+
+const TitleContainer = styled.div`
+  padding: 20px;
+  margin-bottom: 16px;
+  background-color: ${colors.grayScale.white};
+`;
+
+const Title = styled.h1`
+  ${semiBold20}
+  margin-bottom: 20px;
+  color: ${colors.grayScale.gray05};
+`;
+
+const MemberListLabel = styled.span`
+  ${medium12}
+  margin-top: 16px;
+  padding: 20px 20px 8px;
+  display: block;
+  color: ${colors.grayScale.gray05};
+  background-color: ${colors.grayScale.white};
+`;
+
+const ToggleContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
+  margin-top: 16px;
+  padding: 16px 20px;
+  background-color: ${colors.grayScale.white};
+`;
+
+const ToggleLabel = styled.span`
+  ${semiBold16};
+  color: ${colors.grayScale.gray04};
+`;
+
+const AddressInputContainer = styled.div`
+  padding: 0 20px 16px;
+  background-color: ${colors.grayScale.white};
+`;
+
+const SearchInMapButton = styled(TextButton)`
+  display: block;
+  margin: 16px auto 0;
+`;
+
 const Add = () => {
-  return <div>회의 생성 페이지</div>;
+  const {
+    startDatetime,
+    endDatetime,
+    handleChangeEndDatetime,
+    handleChangeStartDatetime
+  } = UseDatetimePicker();
+  const [isOnlineMeeting, setIsOnlineMeeting] = useState(false);
+  const [meetingTitle, setMeetingTitle] = useState('');
+  const [selectedMembers, setSelectedMembers] = useState<number[]>([]);
+
+  const getIsSelected = (id: number) => selectedMembers.includes(id);
+
+  const selectMember = (id: number) => {
+    if (getIsSelected(id)) {
+      setSelectedMembers((pre) => pre.filter((item) => item !== id));
+      return;
+    }
+    setSelectedMembers((pre) => [...pre, id]);
+  };
+
+  const handleMeetingTitleChange: ChangeEventHandler<HTMLInputElement> = ({
+    target: { value }
+  }) => setMeetingTitle(value);
+
+  const handleClickToggle = () => setIsOnlineMeeting((pre) => !pre);
+
+  const handleSearchInMapClick = () => console.log('지도에서 찾기 클릭');
+
+  const handleSubmitNewMeeting = () =>
+    console.log({
+      meetingTitle,
+      startDatetime,
+      endDatetime,
+      selectedMembers
+    });
+
+  return (
+    <Background>
+      <TopNavBar setting={false} backURL="./suggestion" />
+      <TitleContainer>
+        <Title>회의 일정을 등록해보세요.</Title>
+        <TextInput
+          value={meetingTitle}
+          placeholder="회의 일정 제목을 입력하세요."
+          onChange={handleMeetingTitleChange}
+        />
+      </TitleContainer>
+      <TimePicker
+        allDayOption={false}
+        onChangeEndDatetime={handleChangeEndDatetime}
+        onChangeStartDatetime={handleChangeStartDatetime}
+        {...{ startDatetime, endDatetime }}
+      />
+      <MemberListLabel>모임 구성원</MemberListLabel>
+      {MEMBERS_MOCK.map(({ id, src, name }) => (
+        <MemberList
+          key={id}
+          check={true}
+          isChecked={getIsSelected(id)}
+          onChange={() => selectMember(id)}
+          {...{ src, name }}
+        />
+      ))}
+      <ToggleContainer>
+        <ToggleLabel>비대면 회의</ToggleLabel>
+        <Toggle isOn={isOnlineMeeting} onClick={handleClickToggle} />
+      </ToggleContainer>
+      {isOnlineMeeting || (
+        <AddressInputContainer>
+          <TextInput
+            placeholder="주소를 입력하세요."
+            value={''}
+            onChange={function (event: ChangeEvent<HTMLInputElement>): void {
+              throw new Error('Function not implemented.');
+            }}
+          />
+          <SearchInMapButton
+            color="navy"
+            disabled={false}
+            onClick={handleSearchInMapClick}
+          >
+            지도에서 찾기
+          </SearchInMapButton>
+        </AddressInputContainer>
+      )}
+      <ButtonFooter disabled={false} onClick={handleSubmitNewMeeting}>
+        회의 만들기
+      </ButtonFooter>
+    </Background>
+  );
 };
 
 export default Add;

--- a/src/pages/group/meeting/suggestion/index.tsx
+++ b/src/pages/group/meeting/suggestion/index.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import Router from 'next/router';
 import styled from '@emotion/styled';
 
 import { Button, Logo, SuggestionTimeList } from '../../../../components/atoms';
@@ -81,6 +82,8 @@ const AddTimeButton = styled(Button)`
 `;
 
 const Suggestion = () => {
+  const handleClickAddMenually = () => Router.push('./add');
+
   return (
     <>
       <TopNavBar setting={false} backURL="./" />
@@ -111,9 +114,7 @@ const Suggestion = () => {
         width="250px"
         disabled={false}
         color="purple"
-        onClick={function (): void {
-          throw new Error('Function not implemented.');
-        }}
+        onClick={handleClickAddMenually}
       >
         시간 직접 추가하기
       </AddTimeButton>

--- a/src/pages/group/meeting/suggestion/index.tsx
+++ b/src/pages/group/meeting/suggestion/index.tsx
@@ -93,7 +93,11 @@ const Suggestion = () => {
             </Link>
           </TitleContainer>
           {SUGGESTION_TIME_MOCK.map(({ date, time }) => (
-            <SuggestionTimeListStyled key={date + time} {...{ date, time }} />
+            <SuggestionTimeListStyled
+              key={date + time}
+              href="./add"
+              {...{ date, time }}
+            />
           ))}
         </>
       ) : (

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -190,7 +190,7 @@ const Home = () => {
       setIsDisplayModal(true);
       return;
     }
-    Router.push('/group/detail');
+    Router.push('/group/join');
   };
 
   const handleCloseModal = () => {

--- a/src/utils/getRandomString.ts
+++ b/src/utils/getRandomString.ts
@@ -1,0 +1,6 @@
+const getRandomString = () => {
+  const random = Math.random().toString(36).substring(2, 11);
+  return random;
+};
+
+export default getRandomString;


### PR DESCRIPTION
resolved #191

- 추천 시간대를 선택하거나 '시간 직접 추가하기' 버튼을 누르면 이동할 수 있는 회의 생성 페이지를 마크업했습니다(추천 시간대를 눌렀을 때 해당 시간대가 저절로 설정되어 있는 기능은 아직 구현전입니다.).
- 기본적인 인풋 핸들링을 구현하고, '모임 만들기' 버튼을 눌렀을 때 모임 생성 정보가 콘솔에 표시되도록 했습니다.
- '지도에서 찾기' 기능은 별도의 PR로 구현할 예정입니다.

<img width="386" alt="image" src="https://user-images.githubusercontent.com/71015915/198355860-77ecd0ba-a55e-4d10-947d-c83538c09543.png">
