### PR TITLE
SuggestionTimeList 컴포넌트가 선택적으로 링크 컴포넌트가 될 수 있도록 하기

### DIFF
--- a/src/components/atoms/SuggestionTimeList/index.tsx
+++ b/src/components/atoms/SuggestionTimeList/index.tsx
@@ -11,7 +11,14 @@ type Props = {
   href?: string;
 };
 
-const Container = styled.a`
+const LinkContainer = styled.a`
+  display: block;
+  padding: 16px 20px;
+  background-color: ${colors.grayScale.white};
+  text-decoration: none;
+`;
+
+const Container = styled.div`
   display: block;
   padding: 16px 20px;
   background-color: ${colors.grayScale.white};
@@ -30,13 +37,18 @@ const Time = styled.span`
 `;
 
 const SuggestionTimeList = ({ className, date, time, href }: Props) => {
-  return (
-    <Link passHref href={href || ''}>
-      <Container className={className}>
+  return href ? (
+    <Link passHref href={href}>
+      <LinkContainer className={className}>
         <Date>{date}</Date>
         <Time>{time}</Time>
-      </Container>
+      </LinkContainer>
     </Link>
+  ) : (
+    <Container className={className}>
+      <Date>{date}</Date>
+      <Time>{time}</Time>
+    </Container>
   );
 };
 

--- a/src/pages/group/meeting/suggestion/index.tsx
+++ b/src/pages/group/meeting/suggestion/index.tsx
@@ -96,11 +96,7 @@ const Suggestion = () => {
             </Link>
           </TitleContainer>
           {SUGGESTION_TIME_MOCK.map(({ date, time }) => (
-            <SuggestionTimeListStyled
-              key={date + time}
-              href="./add"
-              {...{ date, time }}
-            />
+            <SuggestionTimeListStyled key={date + time} {...{ date, time }} />
           ))}
         </>
       ) : (


### PR DESCRIPTION
resolved #192

SuggestionTimeList가 `href` 프롭을 받을 때는 링크 컴포넌트로, `href` 프롭이 없을 때는 일반 `div` 컴포넌트로 사용될 수 있도록 리펙토링했습니다.