### PR TITLE
모임 설정 페이지의 모임 정보 탭에서 폼 제출 기능 구현

### DIFF
--- a/src/components/molecules/TagInput/index.tsx
+++ b/src/components/molecules/TagInput/index.tsx
@@ -16,7 +16,6 @@ type Props = {
   placeholder?: string;
   label?: string;
   tagList: string[];
-  isTagExists: boolean;
   addTag: (text: string) => void;
   deleteTag: (index: number) => void;
 };
@@ -55,8 +54,7 @@ const TagInput = ({
   label,
   tagList,
   addTag,
-  deleteTag,
-  isTagExists
+  deleteTag
 }: Props) => {
   const [text, setText] = useState('#');
   const [isTyping, setIsTyping] = useState(false);
@@ -107,10 +105,10 @@ const TagInput = ({
       {label && <Label marginBottom="4px">{label}</Label>}
       <Input
         onClick={handleInputClick}
-        isTagMode={isTyping || isTagExists}
+        isTagMode={isTyping || !!tagList.length}
         ref={dummyInputRef}
       >
-        {isTyping || isTagExists || placeholder}
+        {isTyping || !!tagList.length || placeholder}
         {tagList.map((text, index) => (
           <TagStyled
             key={`text-${index}`}

--- a/src/pages/group/add/basic.tsx
+++ b/src/pages/group/add/basic.tsx
@@ -158,7 +158,6 @@ const Basic = () => {
           <TagInput
             label="태그"
             placeholder="태그를 입력하세요."
-            isTagExists={!!tagList.length}
             {...{ addTag, deleteTag, tagList }}
           />
         </WhiteBox>

--- a/src/pages/group/setting/information.tsx
+++ b/src/pages/group/setting/information.tsx
@@ -1,3 +1,4 @@
+import { ChangeEventHandler, useState } from 'react';
 import styled from '@emotion/styled';
 
 import { Button } from '../../../components/atoms';
@@ -11,6 +12,7 @@ import {
 } from '../../../components/molecules';
 import ButtonFooter from '../../../components/molecules/ButtonFooter';
 import colors from '../../../styles/colors';
+import readFileAsURL from '../../../utils/readFileAsURL';
 
 const Background = styled.div`
   box-sizing: border-box;
@@ -38,6 +40,53 @@ const TextAreaStyled = styled(TextArea)`
 `;
 
 const Information = () => {
+  const [profileImage, setProfileImage] = useState('');
+  const [meetingTitle, setMeetingTitle] = useState('');
+  const [meetingDescription, setMeetingDescription] = useState('');
+  const [tagList, setTagList] = useState<string[]>([]);
+
+  const handleDeleteImage = () => setProfileImage('');
+
+  const handleChangeImageUpload: ChangeEventHandler<HTMLInputElement> = ({
+    target: { files }
+  }) => {
+    if (!files) return;
+    readFileAsURL(files[0], setProfileImage);
+  };
+
+  const handleMeetingTitleChange: ChangeEventHandler<HTMLInputElement> = ({
+    target: { value }
+  }) => setMeetingTitle(value);
+
+  const handleMeetingDescriptionChange: ChangeEventHandler<
+    HTMLTextAreaElement
+  > = ({ target: { value } }) => setMeetingDescription(value);
+
+  const handleAddTag = (text: string) => {
+    const preExists = tagList.includes(text);
+    if (preExists) return;
+    setTagList([...tagList, text]);
+  };
+
+  const deleteTag = (index: number) => {
+    setTagList((pre) => {
+      const deforeTarget = pre.slice(0, index);
+      const afterTarget = pre.slice(index + 1);
+      return [...deforeTarget, ...afterTarget];
+    });
+  };
+
+  const handleClickCloseMeeting = () => console.log('모임 끝내기 클릭');
+
+  const handleMeetingInformationSubmit = () => {
+    console.log({
+      profileImage,
+      meetingTitle,
+      meetingDescription,
+      tagList
+    });
+  };
+
   return (
     <Background>
       <TopNavBar setting={false} backURL="/group" />
@@ -51,20 +100,20 @@ const Information = () => {
         />
       </TabContainer>
       <ImageUploadInput
-        profileImage={''}
-        onClickDeleteImage={() => console.log()}
-        onChangeImageFile={() => console.log()}
+        profileImage={profileImage}
+        onClickDeleteImage={handleDeleteImage}
+        onChangeImageFile={handleChangeImageUpload}
       />
       <WhiteBox>
         <TextInput
-          value={''}
-          onChange={() => console.log()}
+          value={meetingTitle}
+          onChange={handleMeetingTitleChange}
           label="모임 이름"
           placeholder="모임 이름을 입력해주세요."
         />
         <TextAreaStyled
-          value={''}
-          onChange={() => console.log()}
+          value={meetingDescription}
+          onChange={handleMeetingDescriptionChange}
           label="모임 내용"
           placeholder="예시) 저희는 oo을 하는 모임입니다."
         />
@@ -72,10 +121,10 @@ const Information = () => {
       <WhiteBox>
         <TagInput
           label="태그"
-          tagList={[]}
-          isTagExists={false}
-          addTag={() => console.log()}
-          deleteTag={() => console.log()}
+          tagList={tagList}
+          placeholder="태그를 입력해주세요."
+          addTag={handleAddTag}
+          deleteTag={deleteTag}
         />
       </WhiteBox>
       <WhiteBox>
@@ -83,17 +132,12 @@ const Information = () => {
           size="medium"
           disabled={false}
           color="gray"
-          onClick={() => console.log()}
+          onClick={handleClickCloseMeeting}
         >
           모임 끝내기
         </Button>
       </WhiteBox>
-      <ButtonFooter
-        disabled={false}
-        onClick={function (): void {
-          throw new Error('Function not implemented.');
-        }}
-      >
+      <ButtonFooter disabled={false} onClick={handleMeetingInformationSubmit}>
         모임 정보 수정하기
       </ButtonFooter>
     </Background>

--- a/src/pages/group/setting/information.tsx
+++ b/src/pages/group/setting/information.tsx
@@ -1,6 +1,7 @@
-import { ChangeEventHandler, useState } from 'react';
+import { ChangeEventHandler, useEffect, useState } from 'react';
 import styled from '@emotion/styled';
 
+import { DEMO_GROUP_IMAGE_URL } from '../../../__mocks__';
 import { Button } from '../../../components/atoms';
 import {
   ImageUploadInput,
@@ -13,6 +14,13 @@ import {
 import ButtonFooter from '../../../components/molecules/ButtonFooter';
 import colors from '../../../styles/colors';
 import readFileAsURL from '../../../utils/readFileAsURL';
+
+const PRE_GROUP_INFORMATION_MOCK = {
+  profileImage: DEMO_GROUP_IMAGE_URL,
+  meetingTitle: '원래 모임 이름',
+  meetingDescription: '원래 모임 내용',
+  tagList: ['원래 태그1', '원래 태그2', '원래 태그3']
+};
 
 const Background = styled.div`
   box-sizing: border-box;
@@ -44,6 +52,15 @@ const Information = () => {
   const [meetingTitle, setMeetingTitle] = useState('');
   const [meetingDescription, setMeetingDescription] = useState('');
   const [tagList, setTagList] = useState<string[]>([]);
+
+  useEffect(() => {
+    const { profileImage, meetingTitle, meetingDescription, tagList } =
+      PRE_GROUP_INFORMATION_MOCK;
+    setProfileImage(profileImage);
+    setMeetingTitle(meetingTitle);
+    setMeetingDescription(meetingDescription);
+    setTagList(tagList);
+  }, []);
 
   const handleDeleteImage = () => setProfileImage('');
 


### PR DESCRIPTION
resolved #166

- 모임 설정 페이지의 모임 정보 탭에서 프로필 사진, 모임 제목, 설명 및 태그를 입력할 수 있도록 구현했습니다.
- '모임 나가기' 버튼을 누르면 콘솔에 로그가 찍히게 임시로 만들었습니다.
- '모임 정보 수정하기' 버튼을 누르면 수정한(혹은 수정하지 않은) 정보가 콘솔에 출력되도록 했습니다.
- 또한, 목데이터를 사용하여 기존 모임 정보를 불러와 렌더링 시 각각의 인풋에 기본값으로 설정하는 기능을 구현했습니다.