### PR TITLE
모임 설정 페이지의 '모임 정보' 탭에서 '모임 끝내기' 버튼을 눌렀을 때 확인 모달 보여주기

### DIFF
--- a/src/components/molecules/Dialog/Dialog.stories.tsx
+++ b/src/components/molecules/Dialog/Dialog.stories.tsx
@@ -8,6 +8,7 @@ export default {
 } as ComponentMeta<typeof Dialog>;
 
 export const Primary: ComponentStory<typeof Dialog> = ({
+  isOpen = true,
   buttonType = 'one',
   title = '다이얼로그 제목',
   description = '다이얼로그 설명',
@@ -20,6 +21,7 @@ export const Primary: ComponentStory<typeof Dialog> = ({
     return (
       <Dialog
         {...{
+          isOpen,
           buttonType,
           title,
           description: description,
@@ -33,6 +35,7 @@ export const Primary: ComponentStory<typeof Dialog> = ({
   return (
     <Dialog
       {...{
+        isOpen,
         buttonType,
         title,
         description: description,

--- a/src/components/molecules/Dialog/index.tsx
+++ b/src/components/molecules/Dialog/index.tsx
@@ -5,6 +5,7 @@ import { regular16, semiBold20 } from '../../../styles/typography';
 import { Button } from '../../atoms';
 
 type DefaultProps = {
+  isOpen: boolean;
   isIllustrationExists: boolean;
   title: string;
   purpleButtonText: string;
@@ -26,8 +27,8 @@ type TwoButtonProps = {
 
 type Props = OneButtonProps | TwoButtonProps;
 
-const FullPageModal = styled.div`
-  display: flex;
+const FullPageModal = styled.div<Pick<Props, 'isOpen'>>`
+  display: ${({ isOpen }) => (isOpen ? 'flex' : 'none')};
   justify-content: center;
   align-items: center;
   position: fixed;
@@ -77,24 +78,24 @@ const GrayButton = styled(Button)`
   margin-right: 8px;
 `;
 
-const Dialog = (props: Props) => {
-  const {
-    buttonType,
-    title,
-    description,
-    isIllustrationExists,
-    isPurpleButtonDisabled,
-    purpleButtonText,
-    onPurpleButtonClick
-  } = props;
+const Dialog = ({
+  isOpen,
+  title,
+  description,
+  isIllustrationExists,
+  isPurpleButtonDisabled,
+  purpleButtonText,
+  onPurpleButtonClick,
+  ...props
+}: Props) => {
   return (
-    <FullPageModal>
+    <FullPageModal isOpen={isOpen}>
       <Container>
         <Title>{title}</Title>
         {isIllustrationExists && <MockIllustration />}
         <Discription>{description}</Discription>
         <ButtonBox>
-          {buttonType === 'two' && (
+          {props.buttonType === 'two' && (
             <GrayButton
               size="medium"
               disabled={props.isGrayButtonDisabled}

--- a/src/components/molecules/Dialog/index.tsx
+++ b/src/components/molecules/Dialog/index.tsx
@@ -64,8 +64,9 @@ const MockIllustration = styled.div`
 
 const Discription = styled.span`
   ${regular16}
-  margin: 8px 0 16px;
+  margin: 8px 59px 16px;
   color: ${colors.grayScale.gray04};
+  text-align: center;
 `;
 
 const ButtonBox = styled.div`

--- a/src/pages/group/add/basic.tsx
+++ b/src/pages/group/add/basic.tsx
@@ -45,7 +45,7 @@ const Basic = () => {
   const [description, setDescription] = useState('');
   const [numberOfPeople, setNumberOfPeople] = useState(0);
   const [tagList, setTagList] = useState<string[]>([]);
-  const [isModalDisplay, setIsModalDisplay] = useState(false);
+  const [isModalOpen, setIsModalOpen] = useState(false);
   const [profileImage, setProfileImage] = useState('');
   const setProfileImageURLStore = useNewGroupInformationStore(
     (state) => state.setProfileImageURL
@@ -108,24 +108,23 @@ const Basic = () => {
     });
   };
 
-  const backConfirmCallback = () => setIsModalDisplay(true);
+  const backConfirmCallback = () => setIsModalOpen(true);
 
   return (
     <>
-      {isModalDisplay && (
-        <Dialog
-          buttonType="two"
-          title="모임 만들기를 취소하시겠어요?"
-          description="취소한 모임은 저장되지 않습니다."
-          purpleButtonText="아니요"
-          grayButtonText="네, 취소할게요"
-          onGrayButtonClick={() => Router.push('/home')}
-          onPurpleButtonClick={() => setIsModalDisplay(false)}
-          isGrayButtonDisabled={false}
-          isPurpleButtonDisabled={false}
-          isIllustrationExists={true}
-        />
-      )}
+      <Dialog
+        isOpen={isModalOpen}
+        buttonType="two"
+        title="모임 만들기를 취소하시겠어요?"
+        description="취소한 모임은 저장되지 않습니다."
+        purpleButtonText="아니요"
+        grayButtonText="네, 취소할게요"
+        onGrayButtonClick={() => Router.push('/home')}
+        onPurpleButtonClick={() => setIsModalOpen(false)}
+        isGrayButtonDisabled={false}
+        isPurpleButtonDisabled={false}
+        isIllustrationExists={true}
+      />
       <Background>
         <TopNavBar
           setting={false}

--- a/src/pages/group/setting/information.tsx
+++ b/src/pages/group/setting/information.tsx
@@ -1,9 +1,11 @@
 import { ChangeEventHandler, useEffect, useState } from 'react';
+import Router from 'next/router';
 import styled from '@emotion/styled';
 
 import { DEMO_GROUP_IMAGE_URL } from '../../../__mocks__';
 import { Button } from '../../../components/atoms';
 import {
+  Dialog,
   ImageUploadInput,
   SegmentTab,
   TagInput,
@@ -52,6 +54,7 @@ const Information = () => {
   const [meetingTitle, setMeetingTitle] = useState('');
   const [meetingDescription, setMeetingDescription] = useState('');
   const [tagList, setTagList] = useState<string[]>([]);
+  const [isConfirmModalOpen, setIsConfirmModalOpen] = useState(false);
 
   useEffect(() => {
     const { profileImage, meetingTitle, meetingDescription, tagList } =
@@ -93,7 +96,7 @@ const Information = () => {
     });
   };
 
-  const handleClickCloseMeeting = () => console.log('모임 끝내기 클릭');
+  const handleClickCloseMeeting = () => setIsConfirmModalOpen(true);
 
   const handleMeetingInformationSubmit = () => {
     console.log({
@@ -104,60 +107,79 @@ const Information = () => {
     });
   };
 
+  const handleModalClose = () => setIsConfirmModalOpen(false);
+
+  const closeMeeting = () => Router.push('/home');
+
   return (
-    <Background>
-      <TopNavBar setting={false} backURL="/group" />
-      <TabContainer>
-        <SegmentTab
-          leftTabLabel="모임 정보"
-          rightTabLabel="구성원 관리"
-          leftTabHref=""
-          rightTabHref="./member"
-          selectedTabIndex={0}
+    <>
+      <Background>
+        <TopNavBar setting={false} backURL="/group" />
+        <TabContainer>
+          <SegmentTab
+            leftTabLabel="모임 정보"
+            rightTabLabel="구성원 관리"
+            leftTabHref=""
+            rightTabHref="./member"
+            selectedTabIndex={0}
+          />
+        </TabContainer>
+        <ImageUploadInput
+          profileImage={profileImage}
+          onClickDeleteImage={handleDeleteImage}
+          onChangeImageFile={handleChangeImageUpload}
         />
-      </TabContainer>
-      <ImageUploadInput
-        profileImage={profileImage}
-        onClickDeleteImage={handleDeleteImage}
-        onChangeImageFile={handleChangeImageUpload}
+        <WhiteBox>
+          <TextInput
+            value={meetingTitle}
+            onChange={handleMeetingTitleChange}
+            label="모임 이름"
+            placeholder="모임 이름을 입력해주세요."
+          />
+          <TextAreaStyled
+            value={meetingDescription}
+            onChange={handleMeetingDescriptionChange}
+            label="모임 내용"
+            placeholder="예시) 저희는 oo을 하는 모임입니다."
+          />
+        </WhiteBox>
+        <WhiteBox>
+          <TagInput
+            label="태그"
+            tagList={tagList}
+            placeholder="태그를 입력해주세요."
+            addTag={handleAddTag}
+            deleteTag={deleteTag}
+          />
+        </WhiteBox>
+        <WhiteBox>
+          <Button
+            size="medium"
+            disabled={false}
+            color="gray"
+            onClick={handleClickCloseMeeting}
+          >
+            모임 끝내기
+          </Button>
+        </WhiteBox>
+        <ButtonFooter disabled={false} onClick={handleMeetingInformationSubmit}>
+          모임 정보 수정하기
+        </ButtonFooter>
+      </Background>
+      <Dialog
+        isOpen={isConfirmModalOpen}
+        title="정말 모임을 끝내시겠어요?"
+        isIllustrationExists={true}
+        description="모든 팀원들은 모임에서 나가게 되며, 남은 모임비는 자동으로 반환됩니다."
+        buttonType="two"
+        grayButtonText="네, 끝낼게요"
+        purpleButtonText="아니요"
+        onGrayButtonClick={closeMeeting}
+        onPurpleButtonClick={handleModalClose}
+        isGrayButtonDisabled={false}
+        isPurpleButtonDisabled={false}
       />
-      <WhiteBox>
-        <TextInput
-          value={meetingTitle}
-          onChange={handleMeetingTitleChange}
-          label="모임 이름"
-          placeholder="모임 이름을 입력해주세요."
-        />
-        <TextAreaStyled
-          value={meetingDescription}
-          onChange={handleMeetingDescriptionChange}
-          label="모임 내용"
-          placeholder="예시) 저희는 oo을 하는 모임입니다."
-        />
-      </WhiteBox>
-      <WhiteBox>
-        <TagInput
-          label="태그"
-          tagList={tagList}
-          placeholder="태그를 입력해주세요."
-          addTag={handleAddTag}
-          deleteTag={deleteTag}
-        />
-      </WhiteBox>
-      <WhiteBox>
-        <Button
-          size="medium"
-          disabled={false}
-          color="gray"
-          onClick={handleClickCloseMeeting}
-        >
-          모임 끝내기
-        </Button>
-      </WhiteBox>
-      <ButtonFooter disabled={false} onClick={handleMeetingInformationSubmit}>
-        모임 정보 수정하기
-      </ButtonFooter>
-    </Background>
+    </>
   );
 };
 export default Information;

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -173,7 +173,7 @@ const Home = () => {
   const [hasNotification, setHasNotification] = useState(true); // TODO: 알림 존재 여부 API 연동하기.
   const [isGroup, setIsGroup] = useState(false);
   const [isDisplayTimer, setIsDisplayTimer] = useState(false); // TODO: 서버에서 푸쉬 메시지 받아서 타이머 켜기.
-  const [isDisplayModal, setIsDisplayModal] = useState(false);
+  const [isModalOpen, setIsModalOpen] = useState(false);
 
   useEffect(() => {
     setIsGroup(Router.asPath.includes('group'));
@@ -187,29 +187,28 @@ const Home = () => {
 
   const handleJoinClick = () => {
     if (searchText !== '1234') {
-      setIsDisplayModal(true);
+      setIsModalOpen(true);
       return;
     }
     Router.push('/group/join');
   };
 
   const handleCloseModal = () => {
-    setIsDisplayModal(false);
+    setIsModalOpen(false);
   };
 
   return (
     <>
-      {isDisplayModal && (
-        <Dialog
-          buttonType="one"
-          isIllustrationExists={false}
-          title="존재하지 않는 초대 코드입니다."
-          description="초대 코드를 다시 확인해주세요."
-          purpleButtonText="확인"
-          isPurpleButtonDisabled={false}
-          onPurpleButtonClick={handleCloseModal}
-        />
-      )}
+      <Dialog
+        isOpen={isModalOpen}
+        buttonType="one"
+        isIllustrationExists={false}
+        title="존재하지 않는 초대 코드입니다."
+        description="초대 코드를 다시 확인해주세요."
+        purpleButtonText="확인"
+        isPurpleButtonDisabled={false}
+        onPurpleButtonClick={handleCloseModal}
+      />
       <Background>
         <Header>
           <TopBox>


### PR DESCRIPTION
resolved #172

- 사용자가 모임 끝내기 버튼을 눌렀을 때 확인 모달을 보여주는 기능을 구현했습니다.
- 추가로, 모달의 열리고 닫힘을 모달 외부가 아니라 모달 내부에서 프롭을 전달받아 처리하도록 리팩토링했습니다.
- 모달의 `description` 영역에 디자인 가이드에 맞게 좌우 마진을 주었습니다.

![image](https://user-images.githubusercontent.com/71015915/198671685-9adb6fe1-947b-4061-a622-5cdd3af7d737.png)
