### PR TITLE
그룹에서 모임 생성할 때 '지도에서 찾기' 페이지 및 기능 구현

### DIFF
--- a/src/components/molecules/MemberList/index.tsx
+++ b/src/components/molecules/MemberList/index.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react';
 import styled from '@emotion/styled';
 
 import colors from '../../../styles/colors';
@@ -48,11 +49,16 @@ const CheckCircleStyled = styled(CheckCircle)`
 `;
 
 const MemberList = ({ className, src, name, ...props }: Props) => {
-  const inputId = `${name}-check-input-${getRandomString()}`;
+  const [inputID, setInputID] = useState('');
+
+  useEffect(() => {
+    const inputIDWithRandomString = `${name}-check-input-${getRandomString()}`;
+    setInputID(inputIDWithRandomString);
+  }, [name]);
 
   return (
     <>
-      <Container className={className} htmlFor={inputId}>
+      <Container className={className} htmlFor={inputID}>
         <Avatar proptype="image" src={src} />
         <Name>{name}</Name>
         {props.check && (
@@ -68,7 +74,7 @@ const MemberList = ({ className, src, name, ...props }: Props) => {
       </Container>
       {props.check && (
         <DummyInput
-          id={inputId}
+          id={inputID}
           type="checkbox"
           checked={props.isChecked}
           onChange={props.onChange}

--- a/src/hooks/useKakaoMaps.tsx
+++ b/src/hooks/useKakaoMaps.tsx
@@ -15,13 +15,24 @@ const useKakaoMaps = ({ coords, onMapDragEvent }: Props) => {
   const mapRef = useRef<HTMLDivElement>(null);
   const [map, setMap] = useState<any>();
   const [isMapLoaded, setIsMapLoaded] = useState(false);
+  const [center, setCenter] = useState<Coords>(coords);
 
   useEffect(() => {
     window.kakao.maps.load(() => {
       const mapObj = renderKakapMap({ coords, mapRef });
       setMap(mapObj);
-      addMapDragEventHandler({ map: mapObj, eventHandler: onMapDragEvent });
+      addMapDragEventHandler({
+        map: mapObj,
+        eventHandler: () => {
+          const Latlng = mapObj.getCenter();
+          const latitude = Latlng.getLat();
+          const longitude = Latlng.getLng();
+          setCenter([latitude, longitude]);
+          onMapDragEvent();
+        }
+      });
       setIsMapLoaded(true);
+
       return () =>
         removeMapDragEventHandler({
           map: mapObj,
@@ -30,7 +41,7 @@ const useKakaoMaps = ({ coords, onMapDragEvent }: Props) => {
     });
   }, [coords]);
 
-  return { mapRef, map, isMapLoaded };
+  return { mapRef, map, isMapLoaded, center };
 };
 
 export default useKakaoMaps;

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -20,7 +20,7 @@ export default function Document() {
           strategy="beforeInteractive"
           src={`//dapi.kakao.com/v2/maps/sdk.js?appkey=${
             process.env.NEXT_PUBLIC_KAKAO_JAVASCRIPT_KEY as string
-          }&autoload=false`}
+          }&autoload=false&libraries=services`}
         />
       </Head>
       <body>

--- a/src/pages/group/meeting/add.tsx
+++ b/src/pages/group/meeting/add.tsx
@@ -18,27 +18,27 @@ const MEMBERS_MOCK = [
   {
     id: 1,
     src: DEMO_PROFILE_IMAGE_URL,
-    name: '구성원 이름'
+    name: '구성원 이름1'
   },
   {
     id: 2,
     src: DEMO_PROFILE_IMAGE_URL,
-    name: '구성원 이름'
+    name: '구성원 이름2'
   },
   {
     id: 3,
     src: DEMO_PROFILE_IMAGE_URL,
-    name: '구성원 이름'
+    name: '구성원 이름3'
   },
   {
     id: 4,
     src: DEMO_PROFILE_IMAGE_URL,
-    name: '구성원 이름'
+    name: '구성원 이름4'
   },
   {
     id: 5,
     src: DEMO_PROFILE_IMAGE_URL,
-    name: '구성원 이름'
+    name: '구성원 이름5'
   }
 ];
 

--- a/src/pages/group/meeting/add/index.tsx
+++ b/src/pages/group/meeting/add/index.tsx
@@ -1,18 +1,23 @@
 import { ChangeEvent, ChangeEventHandler, useState } from 'react';
+import Router from 'next/router';
 import styled from '@emotion/styled';
 
-import { DEMO_PROFILE_IMAGE_URL } from '../../../__mocks__';
-import { TextButton, Toggle } from '../../../components/atoms';
+import { DEMO_PROFILE_IMAGE_URL } from '../../../../__mocks__';
+import { TextButton, Toggle } from '../../../../components/atoms';
 import {
   MemberList,
   TextInput,
   TopNavBar
-} from '../../../components/molecules';
-import ButtonFooter from '../../../components/molecules/ButtonFooter';
-import TimePicker from '../../../components/molecules/TimePicker';
-import { UseDatetimePicker } from '../../../hooks';
-import colors from '../../../styles/colors';
-import { medium12, semiBold16, semiBold20 } from '../../../styles/typography';
+} from '../../../../components/molecules';
+import ButtonFooter from '../../../../components/molecules/ButtonFooter';
+import TimePicker from '../../../../components/molecules/TimePicker';
+import { UseDatetimePicker } from '../../../../hooks';
+import colors from '../../../../styles/colors';
+import {
+  medium12,
+  semiBold16,
+  semiBold20
+} from '../../../../styles/typography';
 
 const MEMBERS_MOCK = [
   {
@@ -120,7 +125,7 @@ const Add = () => {
 
   const handleClickToggle = () => setIsOnlineMeeting((pre) => !pre);
 
-  const handleSearchInMapClick = () => console.log('지도에서 찾기 클릭');
+  const handleSearchInMapClick = () => Router.push('./add/map');
 
   const handleSubmitNewMeeting = () =>
     console.log({

--- a/src/pages/group/meeting/add/map.tsx
+++ b/src/pages/group/meeting/add/map.tsx
@@ -1,0 +1,133 @@
+import { useEffect, useState } from 'react';
+import styled from '@emotion/styled';
+
+import { Button } from '../../../../components/atoms';
+import { GPSButton, TopNavBar } from '../../../../components/molecules';
+import { useCoords, useKakaoMaps } from '../../../../hooks';
+import colors from '../../../../styles/colors';
+import { shadow01 } from '../../../../styles/mixins';
+import { bold16 } from '../../../../styles/typography';
+import { moveCenterOfMap } from '../../../../utils/kakaoMapsTools';
+
+const MapContainer = styled.div`
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-end;
+  height: calc(100vh - 44px);
+  padding-bottom: 42px;
+  background-color: ${colors.grayScale.gray02};
+`;
+
+const Maker = styled.div`
+  z-index: 3;
+  width: 30px;
+  height: 30px;
+  border-radius: 50% 50% 50% 0;
+  background: ${colors.mainColor.purple};
+  position: absolute;
+  transform: rotate(-45deg);
+  left: 50%;
+  top: 50%;
+  margin: -20px 0 0 -20px;
+  animation-name: bounce;
+  animation-fill-mode: both;
+  animation-duration: 1s;
+
+  &:after {
+    content: '';
+    width: 14px;
+    height: 14px;
+    margin: 8px 0 0 8px;
+    background: ${colors.grayScale.white};
+    position: absolute;
+    border-radius: 50%;
+  }
+`;
+
+const TimerMenuContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  z-index: 3;
+`;
+
+const LocationSelectContainer = styled.div`
+  ${shadow01}
+  box-sizing: border-box;
+  width: 374px;
+  padding: 16px 20px;
+  border-radius: 8px;
+  background-color: ${colors.grayScale.white};
+`;
+
+const Location = styled.h1`
+  ${bold16};
+  margin-bottom: 12px;
+`;
+
+const GPSButtonStyled = styled(GPSButton)`
+  margin-bottom: 16px;
+`;
+
+const Map = () => {
+  const coords = useCoords();
+  const [isGPSButtonActive, setIsGPSButtonActive] = useState(true);
+  const { mapRef, map, center } = useKakaoMaps({
+    coords,
+    onMapDragEvent: () => setIsGPSButtonActive(false)
+  });
+  const [address, setAddress] = useState('지도를 움직여 위치를 선택해주세요.');
+
+  useEffect(() => {
+    window.kakao.maps.load(() => {
+      const geocoder = new window.kakao.maps.services.Geocoder();
+      geocoder.coord2Address(
+        center[1],
+        center[0],
+        (result: any, status: any) => {
+          if (status !== window.kakao.maps.services.Status.OK) return;
+          if (!result[0].road_address) return;
+
+          const roadAddress = result[0].road_address.address_name;
+          const jibunAddress = result[0].address.address_name;
+          setAddress(roadAddress || jibunAddress);
+        }
+      );
+    });
+  }, [center, map]);
+
+  const handleGPSButtonClick = () => {
+    moveCenterOfMap({ map, coords });
+    setIsGPSButtonActive(true);
+  };
+
+  return (
+    <>
+      <TopNavBar setting={false} backURL="./" />
+      <MapContainer id="map" ref={mapRef}>
+        <Maker />
+        <TimerMenuContainer>
+          <GPSButtonStyled
+            selected={isGPSButtonActive}
+            onClick={handleGPSButtonClick}
+          />
+          <LocationSelectContainer>
+            <Location>{address}</Location>
+            <Button
+              color="purple"
+              size="medium"
+              onClick={() => console.log()}
+              disabled={false}
+            >
+              이 위치로 회의장소 설정
+            </Button>
+          </LocationSelectContainer>
+        </TimerMenuContainer>
+      </MapContainer>
+    </>
+  );
+};
+
+export default Map;

--- a/src/pages/group/meeting/add/map.tsx
+++ b/src/pages/group/meeting/add/map.tsx
@@ -103,6 +103,12 @@ const Map = () => {
     setIsGPSButtonActive(true);
   };
 
+  const handleClickSetLocationButton = () => {
+    setAddressStore(address);
+    setCoordsStore(center);
+    Router.push('./');
+  };
+
   return (
     <>
       <TopNavBar setting={false} backURL="./" />
@@ -118,7 +124,7 @@ const Map = () => {
             <Button
               color="purple"
               size="medium"
-              onClick={() => console.log()}
+              onClick={handleClickSetLocationButton}
               disabled={false}
             >
               이 위치로 회의장소 설정

--- a/src/store/meetingLocation.ts
+++ b/src/store/meetingLocation.ts
@@ -1,0 +1,20 @@
+import { mountStoreDevtool } from 'simple-zustand-devtools';
+import create from 'zustand';
+
+type MeetingLocationState = {
+  coords: [number, number];
+  address: string;
+  setCoords: (coords: [number, number]) => void;
+  setAddress: (address: string) => void;
+};
+
+const meetingLocationStore = create<MeetingLocationState>((set) => ({
+  coords: [0, 0],
+  address: '',
+  setCoords: (coords: [number, number]) => set({ coords }),
+  setAddress: (address: string) => set({ address })
+}));
+
+mountStoreDevtool('MeetingLocation', meetingLocationStore);
+
+export default meetingLocationStore;


### PR DESCRIPTION
resolved #194

- 모임을 생성하는 화면에서 '지도에서 찾기' 버튼을 눌렀을 때 이동하는 페이지를 마크업하고, 실제 주소 찾기 기능을 구현했습니다.
- 지도 찾기 페이지에서는 지도 중앙에 마커가 표시되고, 사용자가 지도를 움직여 마커를 원하는 위치에 올려놓는 방식으로 사용할 수 있습니다.
- 사용자가 지도를 움직이다 멈추면 현재 마커 위치에 해당하는 도로명 주소가 버튼 위에 실시간으로 표시되고, 도로명 주소가 없다면 지번 주소가 표시되도록 구현하였습니다(건물이 아닌 위치에 마커를 올려놓았을 때 등).
- 또한, 추후 모임 만들기 페이지에서 약속 장소의 주소와 좌표를 사용할 수 있도록 중앙 상태를 만들었습니다.

추가로, 모임 생성 화면에서 구성원 리스트를 렌더링할 때 서버에서의 태그 `id`와 클라이언트에서의 태그 `id` 값이 다른 문제가 있어, 랜덤으로 `id`를 만드는 함수를 리액트 훅으로 감쌌습니다.

![image](https://user-images.githubusercontent.com/71015915/199233966-91b1a800-f846-4482-b848-253523a135f3.png)
