### PR TITLE
회의 만들기 페이지에서 '지도에서 찾기' 페이지로 다녀오더라도 적었던 내용이 그대로 있게 만들기

### DIFF
--- a/src/components/molecules/TimePicker/TimePicker.stories.tsx
+++ b/src/components/molecules/TimePicker/TimePicker.stories.tsx
@@ -15,11 +15,19 @@ export const Primary: ComponentStory<typeof TimerPicker> = ({
   const {
     startDatetime,
     endDatetime,
-    handleChangeEndDatetime,
-    handleChangeStartDatetime,
+    setStartDatetime,
+    setEndDatetime,
     isToggleOn,
     handleClickToggle
   } = UseDatetimePicker();
+
+  const handleChangeStartDatetime: React.ChangeEventHandler<
+    HTMLInputElement
+  > = ({ target: { value } }) => setStartDatetime(value);
+
+  const handleChangeEndDatetime: React.ChangeEventHandler<HTMLInputElement> = ({
+    target: { value }
+  }) => setEndDatetime(value);
 
   return (
     <TimerPicker

--- a/src/components/molecules/TopNavBar/TopNavBar.stories.tsx
+++ b/src/components/molecules/TopNavBar/TopNavBar.stories.tsx
@@ -15,15 +15,15 @@ export default {
 } as ComponentMeta<typeof TopNavBar>;
 
 export const Primary: ComponentStory<typeof TopNavBar> = ({ setting }) => {
+  const handleBackButtonClick = () => console.log('back button clicked');
+
   return setting ? (
     <TopNavBar
-      {...{
-        setting,
-        backURL: '',
-        settingURL: ''
-      }}
+      setting={setting}
+      settingURL=""
+      onBackButtonClick={handleBackButtonClick}
     />
   ) : (
-    <TopNavBar {...{ setting, backURL: '' }} />
+    <TopNavBar setting={setting} onBackButtonClick={handleBackButtonClick} />
   );
 };

--- a/src/components/molecules/TopNavBar/index.tsx
+++ b/src/components/molecules/TopNavBar/index.tsx
@@ -1,13 +1,11 @@
 import Link from 'next/link';
-import Router from 'next/router';
 import styled from '@emotion/styled';
 
 import colors from '../../../styles/colors';
 import { ArrowLeft, Setting } from '../../atoms/icons';
 
 type DefaultProps = {
-  backURL: string;
-  backConfirmCallback?: () => boolean;
+  onBackButtonClick: () => void;
 };
 
 type OnlyBackButtonProps = {
@@ -40,21 +38,11 @@ const BackButton = styled.button`
 `;
 
 const TopNavBar = (prop: Props) => {
-  const { setting, backURL } = prop;
-
-  const handleBackButtonClick = () => {
-    if (!prop.backConfirmCallback) {
-      Router.push(backURL);
-      return;
-    }
-    const ok = prop.backConfirmCallback();
-    if (!ok) return;
-    Router.push(backURL);
-  };
+  const { setting, onBackButtonClick } = prop;
 
   return (
     <NavBox>
-      <BackButton type="button" onClick={handleBackButtonClick}>
+      <BackButton type="button" onClick={onBackButtonClick}>
         <ArrowLeft width="24px" />
       </BackButton>
       {setting && (

--- a/src/components/molecules/TopNavBar/index.tsx
+++ b/src/components/molecules/TopNavBar/index.tsx
@@ -7,7 +7,7 @@ import { ArrowLeft, Setting } from '../../atoms/icons';
 
 type DefaultProps = {
   backURL: string;
-  backConfirmCallback?: () => void;
+  backConfirmCallback?: () => boolean;
 };
 
 type OnlyBackButtonProps = {
@@ -43,10 +43,12 @@ const TopNavBar = (prop: Props) => {
   const { setting, backURL } = prop;
 
   const handleBackButtonClick = () => {
-    if (prop.backConfirmCallback) {
-      prop.backConfirmCallback();
+    if (!prop.backConfirmCallback) {
+      Router.push(backURL);
       return;
     }
+    const ok = prop.backConfirmCallback();
+    if (!ok) return;
     Router.push(backURL);
   };
 

--- a/src/components/templates/GroupPage/index.tsx
+++ b/src/components/templates/GroupPage/index.tsx
@@ -1,4 +1,5 @@
 import { ReactNode } from 'react';
+import Router from 'next/router';
 import styled from '@emotion/styled';
 
 import colors from '../../../styles/colors';
@@ -53,12 +54,14 @@ const GroupPage = ({
   selectedTabIndex,
   children
 }: Props) => {
+  const handleBackButtonClick = () => Router.push('/home');
+
   return (
     <Background className={className}>
       <TopNavBar
-        backURL="/home"
         setting={true}
         settingURL="/group/setting/information"
+        onBackButtonClick={handleBackButtonClick}
       />
       <GroupName>{groupName}</GroupName>
       <NavigationBox>

--- a/src/hooks/useDatetimePicker.ts
+++ b/src/hooks/useDatetimePicker.ts
@@ -1,4 +1,4 @@
-import { ChangeEvent, ChangeEventHandler, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 const MILLISECOND_SCALING_VALUE = 60000;
 const DATETIME_START_INDEX = 0;
@@ -17,49 +17,38 @@ const UseDatetimePicker = () => {
     DATETIME_END_INDEX
   );
   const [isToggleOn, setIsToggleOn] = useState(false);
-  const [startDatetime, setStartDatetime] = useState(todayDatetime);
-  const [endDatetime, setEndDatetime] = useState(todayDatetime);
+  const [startDatetime, setStartDatetimeState] = useState(todayDatetime);
+  const [endDatetime, setEndDatetimeState] = useState(todayDatetime);
 
   useEffect(() => {
     if (isToggleOn) {
-      setStartDatetime((pre) => pre.slice(DATE_START_INDEX, DATE_END_INDEX));
-      setEndDatetime((pre) => pre.slice(DATE_START_INDEX, DATE_END_INDEX));
+      setStartDatetimeState((pre) =>
+        pre.slice(DATE_START_INDEX, DATE_END_INDEX)
+      );
+      setEndDatetimeState((pre) => pre.slice(DATE_START_INDEX, DATE_END_INDEX));
       return;
     }
     if (startDatetime.length <= DATE_END_INDEX)
-      setStartDatetime((pre) => pre + DEFAULT_ISO_TIME_VALUE);
+      setStartDatetimeState((pre) => pre + DEFAULT_ISO_TIME_VALUE);
     if (endDatetime.length <= DATE_END_INDEX)
-      setEndDatetime((pre) => pre + DEFAULT_ISO_TIME_VALUE);
+      setEndDatetimeState((pre) => pre + DEFAULT_ISO_TIME_VALUE);
     // useEffect 내에서 startDatetime과 endDatetime을 사용하고 있지만 이 effect는 오직 isToggleOn에 의해서만 실행되어야 합니다.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isToggleOn]);
 
-  const handleChangeDatetime = (
-    { target: { value } }: ChangeEvent<HTMLInputElement>,
-    target: TargetDatetime
-  ) => {
-    if (target === 'start') {
-      setStartDatetime(value);
-      return;
-    }
-    setEndDatetime(value);
-  };
+  const setStartDatetime = (startDateTime: string) =>
+    setStartDatetimeState(startDateTime);
 
-  const handleChangeStartDatetime: ChangeEventHandler<HTMLInputElement> = (
-    event
-  ) => handleChangeDatetime(event, 'start');
-
-  const handleChangeEndDatetime: ChangeEventHandler<HTMLInputElement> = (
-    event
-  ) => handleChangeDatetime(event, 'end');
+  const setEndDatetime = (endDateTime: string) =>
+    setEndDatetimeState(endDateTime);
 
   const handleClickToggle = () => setIsToggleOn((pre) => !pre);
 
   return {
     startDatetime,
     endDatetime,
-    handleChangeStartDatetime,
-    handleChangeEndDatetime,
+    setStartDatetime,
+    setEndDatetime,
     isToggleOn,
     handleClickToggle
   };

--- a/src/pages/group/add/basic.tsx
+++ b/src/pages/group/add/basic.tsx
@@ -126,11 +126,7 @@ const Basic = () => {
         isIllustrationExists={true}
       />
       <Background>
-        <TopNavBar
-          setting={false}
-          backURL="/home"
-          backConfirmCallback={backConfirmCallback}
-        />
+        <TopNavBar setting={false} onBackButtonClick={backConfirmCallback} />
         <WhiteBox hasMargin={false}>
           <Title>새로운 모임을 만들어보세요.</Title>
         </WhiteBox>

--- a/src/pages/group/add/more.tsx
+++ b/src/pages/group/add/more.tsx
@@ -154,9 +154,11 @@ const More = () => {
     Router.push('./success');
   };
 
+  const handleBackButtonClick = () => Router.push('./basic');
+
   return (
     <Background>
-      <TopNavBar setting={false} backURL="./basic" />
+      <TopNavBar setting={false} onBackButtonClick={handleBackButtonClick} />
       <WhiteBox>
         <Title>기프티콘을 통해 모임비를 정해보세요.</Title>
       </WhiteBox>

--- a/src/pages/group/join/form.tsx
+++ b/src/pages/group/join/form.tsx
@@ -47,9 +47,11 @@ const Form = () => {
     target: { value }
   }) => setText(value);
 
+  const handleBackButtonClick = () => Router.push('./detail');
+
   return (
     <Background>
-      <TopNavBar setting={false} backURL="./detail" />
+      <TopNavBar setting={false} onBackButtonClick={handleBackButtonClick} />
       <WhiteBox>
         <Title>자유롭게 본인을 소개해주세요!</Title>
         <Description>

--- a/src/pages/group/join/index.tsx
+++ b/src/pages/group/join/index.tsx
@@ -67,49 +67,53 @@ const Money = styled.strong`
   color: ${colors.mainColor.purple};
 `;
 
-const Detail = () => (
-  <Background>
-    <TopNavBar backURL="/home" setting={false} />
-    <Image
-      src={DEMO_GROUP_IMAGE_URL}
-      alt="모임 프로필 이미지"
-      layout="responsive"
-      height="250px"
-      width="414"
-    />
-    <WhiteBox>
-      <GroupName>모임 이름</GroupName>
-      <Description>
-        Lorem ipsum dolor, sit amet consectetur adipisicing elit. Aut
-        accusantium autem fugit, odio in, excepturi voluptatum quia quaerat
-        exercitationem, quidem esse corporis sequi. Officiis asperiores illo,
-        necessitatibus ex tempore molestiae voluptas ullam maxime beatae quaerat
-        hic earum. Nemo voluptas a, molestiae rerum et unde esse. Suscipit illum
-        sit tenetur provident.
-      </Description>
-      <TagBox>
-        <GroupTag type="default">태그</GroupTag>
-        <GroupTag type="default">태그</GroupTag>
-        <GroupTag type="default">태그</GroupTag>
-        <GroupTag type="default">태그</GroupTag>
-      </TagBox>
-    </WhiteBox>
-    <WhiteBox>
-      <SubTitle>팀원(5)</SubTitle>
-      <ProfileBox>
-        <ProfileImage proptype="image" src={DEMO_PROFILE_IMAGE_URL} />
-        <ProfileImage proptype="image" src={DEMO_PROFILE_IMAGE_URL} />
-        <ProfileImage proptype="image" src={DEMO_PROFILE_IMAGE_URL} />
-      </ProfileBox>
-    </WhiteBox>
-    <WhiteBox>
-      <SubTitle>모임비</SubTitle>
-      <Money>50,000원</Money>
-    </WhiteBox>
-    <ButtonFooter disabled={false} onClick={() => Router.push('./join/form')}>
-      가입 초대받기
-    </ButtonFooter>
-  </Background>
-);
+const Detail = () => {
+  const handleBackButtonClick = () => Router.push('/home');
+
+  return (
+    <Background>
+      <TopNavBar onBackButtonClick={handleBackButtonClick} setting={false} />
+      <Image
+        src={DEMO_GROUP_IMAGE_URL}
+        alt="모임 프로필 이미지"
+        layout="responsive"
+        height="250px"
+        width="414"
+      />
+      <WhiteBox>
+        <GroupName>모임 이름</GroupName>
+        <Description>
+          Lorem ipsum dolor, sit amet consectetur adipisicing elit. Aut
+          accusantium autem fugit, odio in, excepturi voluptatum quia quaerat
+          exercitationem, quidem esse corporis sequi. Officiis asperiores illo,
+          necessitatibus ex tempore molestiae voluptas ullam maxime beatae
+          quaerat hic earum. Nemo voluptas a, molestiae rerum et unde esse.
+          Suscipit illum sit tenetur provident.
+        </Description>
+        <TagBox>
+          <GroupTag type="default">태그</GroupTag>
+          <GroupTag type="default">태그</GroupTag>
+          <GroupTag type="default">태그</GroupTag>
+          <GroupTag type="default">태그</GroupTag>
+        </TagBox>
+      </WhiteBox>
+      <WhiteBox>
+        <SubTitle>팀원(5)</SubTitle>
+        <ProfileBox>
+          <ProfileImage proptype="image" src={DEMO_PROFILE_IMAGE_URL} />
+          <ProfileImage proptype="image" src={DEMO_PROFILE_IMAGE_URL} />
+          <ProfileImage proptype="image" src={DEMO_PROFILE_IMAGE_URL} />
+        </ProfileBox>
+      </WhiteBox>
+      <WhiteBox>
+        <SubTitle>모임비</SubTitle>
+        <Money>50,000원</Money>
+      </WhiteBox>
+      <ButtonFooter disabled={false} onClick={() => Router.push('./join/form')}>
+        가입 초대받기
+      </ButtonFooter>
+    </Background>
+  );
+};
 
 export default Detail;

--- a/src/pages/group/meeting/add/index.tsx
+++ b/src/pages/group/meeting/add/index.tsx
@@ -163,16 +163,12 @@ const Add = () => {
     setStartDatetimeStore('');
     setEndDatetimeStore('');
     setParticipants([]);
-    return true;
+    Router.push('./suggestion');
   };
 
   return (
     <Background>
-      <TopNavBar
-        setting={false}
-        backURL="./suggestion"
-        backConfirmCallback={handleBackButtonClick}
-      />
+      <TopNavBar setting={false} onBackButtonClick={handleBackButtonClick} />
       <TitleContainer>
         <Title>회의 일정을 등록해보세요.</Title>
         <TextInput

--- a/src/pages/group/meeting/add/index.tsx
+++ b/src/pages/group/meeting/add/index.tsx
@@ -12,6 +12,7 @@ import {
 import ButtonFooter from '../../../../components/molecules/ButtonFooter';
 import TimePicker from '../../../../components/molecules/TimePicker';
 import { UseDatetimePicker } from '../../../../hooks';
+import useNewMeetingFormStore from '../../../../store/meetingLocation';
 import colors from '../../../../styles/colors';
 import {
   medium12,
@@ -99,29 +100,51 @@ const SearchInMapButton = styled(TextButton)`
 `;
 
 const Add = () => {
-  const {
-    startDatetime,
-    endDatetime,
-    handleChangeEndDatetime,
-    handleChangeStartDatetime
-  } = UseDatetimePicker();
+  const { startDatetime, endDatetime, setStartDatetime, setEndDatetime } =
+    UseDatetimePicker();
   const [isOnlineMeeting, setIsOnlineMeeting] = useState(false);
-  const [meetingTitle, setMeetingTitle] = useState('');
-  const [selectedMembers, setSelectedMembers] = useState<number[]>([]);
+  const title = useNewMeetingFormStore((state) => state.title);
+  const startDateStored = useNewMeetingFormStore((state) => state.startDate);
+  const endDateStored = useNewMeetingFormStore((state) => state.endDate);
+  const participants = useNewMeetingFormStore((state) => state.participants);
+  const setTitle = useNewMeetingFormStore((state) => state.setTitle);
+  const setStartDatetimeStore = useNewMeetingFormStore(
+    (state) => state.setStartDate
+  );
+  const setEndDatetimeStore = useNewMeetingFormStore(
+    (state) => state.setEndDate
+  );
+  const setParticipants = useNewMeetingFormStore(
+    (state) => state.setParticipants
+  );
 
-  const getIsSelected = (id: number) => selectedMembers.includes(id);
+  const getIsSelected = (id: number) => participants.includes(id);
 
   const selectMember = (id: number) => {
     if (getIsSelected(id)) {
-      setSelectedMembers((pre) => pre.filter((item) => item !== id));
+      setParticipants(participants.filter((item) => item !== id));
       return;
     }
-    setSelectedMembers((pre) => [...pre, id]);
+    setParticipants([...participants, id]);
   };
 
   const handleMeetingTitleChange: ChangeEventHandler<HTMLInputElement> = ({
     target: { value }
-  }) => setMeetingTitle(value);
+  }) => setTitle(value);
+
+  const handleStartDateTimeChange: ChangeEventHandler<HTMLInputElement> = ({
+    target: { value }
+  }) => {
+    setStartDatetime(value);
+    setStartDatetimeStore(value);
+  };
+
+  const handleEndDateTimeChange: ChangeEventHandler<HTMLInputElement> = ({
+    target: { value }
+  }) => {
+    setEndDatetime(value);
+    setEndDatetimeStore(value);
+  };
 
   const handleClickToggle = () => setIsOnlineMeeting((pre) => !pre);
 
@@ -129,28 +152,41 @@ const Add = () => {
 
   const handleSubmitNewMeeting = () =>
     console.log({
-      meetingTitle,
+      title,
       startDatetime,
       endDatetime,
-      selectedMembers
+      participants
     });
+
+  const handleBackButtonClick = () => {
+    setTitle('');
+    setStartDatetimeStore('');
+    setEndDatetimeStore('');
+    setParticipants([]);
+    return true;
+  };
 
   return (
     <Background>
-      <TopNavBar setting={false} backURL="./suggestion" />
+      <TopNavBar
+        setting={false}
+        backURL="./suggestion"
+        backConfirmCallback={handleBackButtonClick}
+      />
       <TitleContainer>
         <Title>회의 일정을 등록해보세요.</Title>
         <TextInput
-          value={meetingTitle}
+          value={title}
           placeholder="회의 일정 제목을 입력하세요."
           onChange={handleMeetingTitleChange}
         />
       </TitleContainer>
       <TimePicker
         allDayOption={false}
-        onChangeEndDatetime={handleChangeEndDatetime}
-        onChangeStartDatetime={handleChangeStartDatetime}
-        {...{ startDatetime, endDatetime }}
+        onChangeStartDatetime={handleStartDateTimeChange}
+        onChangeEndDatetime={handleEndDateTimeChange}
+        startDatetime={startDateStored || startDatetime}
+        endDatetime={endDateStored || endDatetime}
       />
       <MemberListLabel>모임 구성원</MemberListLabel>
       {MEMBERS_MOCK.map(({ id, src, name }) => (

--- a/src/pages/group/meeting/add/map.tsx
+++ b/src/pages/group/meeting/add/map.tsx
@@ -1,9 +1,11 @@
 import { useEffect, useState } from 'react';
+import Router from 'next/router';
 import styled from '@emotion/styled';
 
 import { Button } from '../../../../components/atoms';
 import { GPSButton, TopNavBar } from '../../../../components/molecules';
 import { useCoords, useKakaoMaps } from '../../../../hooks';
+import useNewMeetingFormStore from '../../../../store/meetingLocation';
 import colors from '../../../../styles/colors';
 import { shadow01 } from '../../../../styles/mixins';
 import { bold16 } from '../../../../styles/typography';
@@ -79,6 +81,8 @@ const Map = () => {
     onMapDragEvent: () => setIsGPSButtonActive(false)
   });
   const [address, setAddress] = useState('지도를 움직여 위치를 선택해주세요.');
+  const setAddressStore = useNewMeetingFormStore((state) => state.setAddress);
+  const setCoordsStore = useNewMeetingFormStore((state) => state.setCoords);
 
   useEffect(() => {
     window.kakao.maps.load(() => {

--- a/src/pages/group/meeting/add/map.tsx
+++ b/src/pages/group/meeting/add/map.tsx
@@ -113,9 +113,11 @@ const Map = () => {
     Router.push('./');
   };
 
+  const handleBackButtonClick = () => Router.push('./');
+
   return (
     <>
-      <TopNavBar setting={false} backURL="./" />
+      <TopNavBar setting={false} onBackButtonClick={handleBackButtonClick} />
       <MapContainer id="map" ref={mapRef}>
         <Maker />
         <TimerMenuContainer>

--- a/src/pages/group/meeting/suggestion/edit.tsx
+++ b/src/pages/group/meeting/suggestion/edit.tsx
@@ -1,3 +1,5 @@
+import { ChangeEventHandler } from 'react';
+import Router from 'next/router';
 import styled from '@emotion/styled';
 
 import { Button, SuggestionTimeList } from '../../../../components/atoms';
@@ -62,26 +64,32 @@ const Description = styled.span`
 `;
 
 const Edit = () => {
-  const {
-    startDatetime,
-    endDatetime,
-    handleChangeEndDatetime,
-    handleChangeStartDatetime
-  } = UseDatetimePicker();
+  const { startDatetime, endDatetime, setStartDatetime, setEndDatetime } =
+    UseDatetimePicker();
 
   const handleExcludedTimeSumbit = () =>
     console.log(startDatetime, endDatetime);
 
+  const handleStartDatetimeChange: ChangeEventHandler<HTMLInputElement> = ({
+    target: { value }
+  }) => setStartDatetime(value);
+
+  const handleEndDatetimeChange: ChangeEventHandler<HTMLInputElement> = ({
+    target: { value }
+  }) => setEndDatetime(value);
+
+  const handleBackButtonClick = () => Router.push('./');
+
   return (
     <Background>
-      <TopNavBar backURL="./" setting={false} />
+      <TopNavBar onBackButtonClick={handleBackButtonClick} setting={false} />
       <WhiteBox>
         <Title>회의가 불가능한 시간들이애요.</Title>
       </WhiteBox>
       <TimePicker
         allDayOption={false}
-        onChangeEndDatetime={handleChangeEndDatetime}
-        onChangeStartDatetime={handleChangeStartDatetime}
+        onChangeStartDatetime={handleStartDatetimeChange}
+        onChangeEndDatetime={handleEndDatetimeChange}
         {...{ startDatetime, endDatetime }}
       />
       <WhiteBox>

--- a/src/pages/group/meeting/suggestion/index.tsx
+++ b/src/pages/group/meeting/suggestion/index.tsx
@@ -84,9 +84,11 @@ const AddTimeButton = styled(Button)`
 const Suggestion = () => {
   const handleClickAddMenually = () => Router.push('./add');
 
+  const handleBackButtonClick = () => Router.push('./');
+
   return (
     <>
-      <TopNavBar setting={false} backURL="./" />
+      <TopNavBar setting={false} onBackButtonClick={handleBackButtonClick} />
       {SUGGESTION_TIME_MOCK.length ? (
         <>
           <TitleContainer>

--- a/src/pages/group/setting/information.tsx
+++ b/src/pages/group/setting/information.tsx
@@ -111,10 +111,12 @@ const Information = () => {
 
   const closeMeeting = () => Router.push('/home');
 
+  const handleBackButtonClick = () => Router.push('/group');
+
   return (
     <>
       <Background>
-        <TopNavBar setting={false} backURL="/group" />
+        <TopNavBar setting={false} onBackButtonClick={handleBackButtonClick} />
         <TabContainer>
           <SegmentTab
             leftTabLabel="모임 정보"

--- a/src/pages/group/setting/member.tsx
+++ b/src/pages/group/setting/member.tsx
@@ -1,3 +1,4 @@
+import Router from 'next/router';
 import styled from '@emotion/styled';
 
 import { DEMO_PROFILE_IMAGE_URL } from '../../../__mocks__';
@@ -90,9 +91,11 @@ const WhiteBox = styled.div`
 `;
 
 const Member = () => {
+  const handleBackButtonClick = () => Router.push('/group');
+
   return (
     <Background>
-      <TopNavBar backURL="/group" setting={false} />
+      <TopNavBar onBackButtonClick={handleBackButtonClick} setting={false} />
       <TabContainer>
         <SegmentTab
           leftTabLabel="모임 정보"

--- a/src/pages/group/timer/map.tsx
+++ b/src/pages/group/timer/map.tsx
@@ -92,9 +92,11 @@ const TimerMap = () => {
     setIsGPSButtonActive(true);
   };
 
+  const handleBackButtonClick = () => Router.push('/home');
+
   return (
     <>
-      <TopNavBar backURL="/home" setting={false} />
+      <TopNavBar onBackButtonClick={handleBackButtonClick} setting={false} />
       <Map id="map" ref={mapRef}>
         <TimerMenuContainer>
           <GPSButtonStyled

--- a/src/pages/notifications.tsx
+++ b/src/pages/notifications.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import Router from 'next/router';
 import styled from '@emotion/styled';
 
 import { Calendar } from '../components/atoms/icons';
@@ -92,9 +93,11 @@ const Notifications = () => {
   const handleReadAllButton = () => setNotifications([]);
   // TODO: 알림 불러오기, 삭제하기 -> 실제 API 연동하기.
 
+  const handleBackButtonClick = () => Router.push('/home');
+
   return (
     <>
-      <TopNavBar backURL="/home" setting={false} />
+      <TopNavBar onBackButtonClick={handleBackButtonClick} setting={false} />
       <ButtonContainer>
         <ReadAllButton type="button" onClick={handleReadAllButton}>
           모두 읽기

--- a/src/pages/setting.tsx
+++ b/src/pages/setting.tsx
@@ -34,7 +34,10 @@ const WithdrawalLink = styled.a`
 const setting = () => {
   return (
     <Background>
-      <TopNavBar backURL="" setting={false} />
+      <TopNavBar
+        onBackButtonClick={() => console.log('뒤로가기')}
+        setting={false}
+      />
       <WhiteBox>
         <List href="">설정</List>
         <List href="">설정</List>

--- a/src/store/meetingLocation.ts
+++ b/src/store/meetingLocation.ts
@@ -1,20 +1,36 @@
 import { mountStoreDevtool } from 'simple-zustand-devtools';
 import create from 'zustand';
 
-type MeetingLocationState = {
+type NewMeetingFormState = {
+  title: string;
+  startDate: string;
+  endDate: string;
+  participants: number[];
   coords: [number, number];
   address: string;
+  setTitle: (title: string) => void;
+  setStartDate: (startDate: string) => void;
+  setEndDate: (endDate: string) => void;
+  setParticipants: (participants: number[]) => void;
   setCoords: (coords: [number, number]) => void;
   setAddress: (address: string) => void;
 };
 
-const meetingLocationStore = create<MeetingLocationState>((set) => ({
+const useNewMeetingFormStore = create<NewMeetingFormState>((set) => ({
+  title: '',
+  startDate: '',
+  endDate: '',
+  participants: [],
   coords: [0, 0],
   address: '',
-  setCoords: (coords: [number, number]) => set({ coords }),
-  setAddress: (address: string) => set({ address })
+  setTitle: (title) => set({ title }),
+  setStartDate: (startDate) => set({ startDate }),
+  setEndDate: (endDate) => set({ endDate }),
+  setParticipants: (participants) => set({ participants }),
+  setCoords: (coords) => set({ coords }),
+  setAddress: (address) => set({ address })
 }));
 
-mountStoreDevtool('MeetingLocation', meetingLocationStore);
+mountStoreDevtool('MeetingLocation', useNewMeetingFormStore);
 
-export default meetingLocationStore;
+export default useNewMeetingFormStore;


### PR DESCRIPTION
resolved #199

- 사용자가 회의를 만드는 페이지에서 '지도에서 찾기' 페이지에 다녀오더라도 기존에 입력한 정보가 남아있어야 합니다.
- 따라서 입력한 정보를 중앙 상태로 관리하고, 회의를 만드는 페이지에서 뒤로가기 버튼을 눌렀을 경우에만 사용자가 입력한 정보를 지우도록 합니다.
- 위의 적은 작업을 하면서 `TopNavBar` 컴포넌트와 `useTimePicker` 훅에서 몇 가지 부분을 바꿨습니다.
  - 기존에는 `TopNavBar` 컴포넌트가 뒤로가기 버튼을 눌렀을 때 도착하는 페이지의 URL과 뒤로가기 버튼을 눌렀을 때 어떤 동작이 일어나게 만드는 콜백 함수를 받았습니다.
  - 이제 `TopNavBar` 컴포넌트는 오직 콜백 함수만 받으며, 콜백 함수 안에서 사용자를 다른 페이지로 보내는 동작을 처리해야 합니다.
  - `useTimePicker` 훅은 사용자가 시작 시간과 마치는 시간 값을 각각 바꿨을 때 실행되는 `input` 태그의 `ChangeEventHandler`를 직접 반환했습니다.
  - 이제 `useTimePicker` 훅은 체인지 핸들러 전체가 아닌, `setStartDatetime`과 `setEndDatetime` 함수를 반환합니다.
  - 따라서 이 훅을 사용하는 컴포넌트에서는 이 두 함수를 가지고 체인지 이벤트 핸들러를 스스로 만들어야 합니다.