### PR TITLE
모임 일정 생성 API 연동하기

### DIFF
--- a/src/api/customAxios.ts
+++ b/src/api/customAxios.ts
@@ -11,14 +11,15 @@ const customAxios = axios.create({
   baseURL: process.env.NEXT_PUBLIC_BASE_REQUEST_URL
 });
 
-// API 서버의 토큰 검증 오류로 인해 잠시 주석 처리.
-// customAxios.interceptors.request.use((config) => {
-//   const accessToken = getCookie(ACCESS_TOKEN_KEY);
-//   if (!config.headers) return config;
-//   if (config.url !== 'auth/kakao/login')
-//     config.headers['x-access-token'] = accessToken ? accessToken : '';
-//   return config;
-// });
+export const requestIntercepter = customAxios.interceptors.request.use(
+  (config) => {
+    const accessToken = getCookie(ACCESS_TOKEN_KEY);
+    if (!config.headers) return config;
+    if (config.url !== 'auth/kakao/login')
+      config.headers['x-access-token'] = accessToken ? accessToken : '';
+    return config;
+  }
+);
 
 customAxios.interceptors.response.use(
   (response) => response,

--- a/src/api/customAxios.ts
+++ b/src/api/customAxios.ts
@@ -11,13 +11,14 @@ const customAxios = axios.create({
   baseURL: process.env.NEXT_PUBLIC_BASE_REQUEST_URL
 });
 
-customAxios.interceptors.request.use((config) => {
-  const accessToken = getCookie(ACCESS_TOKEN_KEY);
-  if (!config.headers) return config;
-  if (config.url !== 'auth/kakao/login')
-    config.headers['x-access-token'] = accessToken ? accessToken : '';
-  return config;
-});
+// API 서버의 토큰 검증 오류로 인해 잠시 주석 처리.
+// customAxios.interceptors.request.use((config) => {
+//   const accessToken = getCookie(ACCESS_TOKEN_KEY);
+//   if (!config.headers) return config;
+//   if (config.url !== 'auth/kakao/login')
+//     config.headers['x-access-token'] = accessToken ? accessToken : '';
+//   return config;
+// });
 
 customAxios.interceptors.response.use(
   (response) => response,

--- a/src/hooks/api/room/schedule/index.ts
+++ b/src/hooks/api/room/schedule/index.ts
@@ -1,6 +1,6 @@
 import { useMutation } from '@tanstack/react-query';
 
-import customAxios from '../../../../api/customAxios';
+import customAxios, { requestIntercepter } from '../../../../api/customAxios';
 
 type PostNewRoomScheduleBody = {
   title: string;
@@ -23,6 +23,9 @@ type PostNewRoomScheduleResponse = {
 type PostNewRoomSchedule = (
   body: PostNewRoomScheduleBody
 ) => Promise<PostNewRoomScheduleResponse>;
+
+// access token 검증 오류가 해결될 때까지 토큰을 싣지 않고 요청.
+customAxios.interceptors.request.eject(requestIntercepter);
 
 const postNewRoomSchedule: PostNewRoomSchedule = async (body) =>
   customAxios.post('/room/schedule', body);

--- a/src/hooks/api/room/schedule/index.ts
+++ b/src/hooks/api/room/schedule/index.ts
@@ -1,0 +1,32 @@
+import { useMutation } from '@tanstack/react-query';
+
+import customAxios from '../../../../api/customAxios';
+
+type PostNewRoomScheduleBody = {
+  title: string;
+  startTime: string;
+  endTime: string;
+  meetingLocation: {
+    address: string;
+    longitude: string;
+    latitude: string;
+  };
+  roomId: number;
+  participantsIds: number[];
+};
+
+type PostNewRoomScheduleResponse = {
+  success: boolean;
+  data: Omit<PostNewRoomScheduleBody, 'participantsIds' | 'roomId'>;
+};
+
+type PostNewRoomSchedule = (
+  body: PostNewRoomScheduleBody
+) => Promise<PostNewRoomScheduleResponse>;
+
+const postNewRoomSchedule: PostNewRoomSchedule = async (body) =>
+  customAxios.post('/room/schedule', body);
+
+const usePostNewRoomSchedule = () => useMutation(postNewRoomSchedule);
+
+export default usePostNewRoomSchedule;

--- a/src/pages/group/meeting/add/index.tsx
+++ b/src/pages/group/meeting/add/index.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, ChangeEventHandler, useState } from 'react';
+import { ChangeEventHandler, useState } from 'react';
 import Router from 'next/router';
 import styled from '@emotion/styled';
 
@@ -12,6 +12,7 @@ import {
 import ButtonFooter from '../../../../components/molecules/ButtonFooter';
 import TimePicker from '../../../../components/molecules/TimePicker';
 import { UseDatetimePicker } from '../../../../hooks';
+import usePostNewRoomSchedule from '../../../../hooks/api/room/schedule';
 import useNewMeetingFormStore from '../../../../store/meetingLocation';
 import colors from '../../../../styles/colors';
 import {
@@ -108,6 +109,8 @@ const Add = () => {
   const endDateStored = useNewMeetingFormStore((state) => state.endDate);
   const participants = useNewMeetingFormStore((state) => state.participants);
   const setTitle = useNewMeetingFormStore((state) => state.setTitle);
+  const address = useNewMeetingFormStore((state) => state.address);
+  const coords = useNewMeetingFormStore((state) => state.coords);
   const setStartDatetimeStore = useNewMeetingFormStore(
     (state) => state.setStartDate
   );
@@ -117,6 +120,7 @@ const Add = () => {
   const setParticipants = useNewMeetingFormStore(
     (state) => state.setParticipants
   );
+  const { isError, isLoading, mutate, isSuccess } = usePostNewRoomSchedule();
 
   const getIsSelected = (id: number) => participants.includes(id);
 
@@ -150,13 +154,21 @@ const Add = () => {
 
   const handleSearchInMapClick = () => Router.push('./add/map');
 
-  const handleSubmitNewMeeting = () =>
-    console.log({
+  const handleSubmitNewMeeting = () => {
+    // room 도메인 API가 수정될 때까지 더미 데이터를 임시로 사용합니다.
+    mutate({
       title,
-      startDatetime,
-      endDatetime,
-      participants
+      startTime: startDatetime,
+      endTime: endDatetime,
+      participantsIds: [3, 6, 48],
+      meetingLocation: {
+        address,
+        latitude: coords[0].toString(10),
+        longitude: coords[1].toString(10)
+      },
+      roomId: 66
     });
+  };
 
   const handleBackButtonClick = () => {
     setTitle('');
@@ -202,10 +214,8 @@ const Add = () => {
         <AddressInputContainer>
           <TextInput
             placeholder="주소를 입력하세요."
-            value={''}
-            onChange={function (event: ChangeEvent<HTMLInputElement>): void {
-              throw new Error('Function not implemented.');
-            }}
+            value={address}
+            onChange={() => {}}
           />
           <SearchInMapButton
             color="navy"


### PR DESCRIPTION
resolved #204

- 모임 일정을 생성하는 API를 연동하였습니다.
- 현재 `x-access-token`이 요청 헤더에 포함되면 서버에서 오류가 나는 관계로, 임시로 토큰을 싣지 않고 요청을 보냈습니다.
- 아직 `/room` 도메인 관련 API 연결이 안 되어서 몇몇 더미 데이터로 요청을 보냅니다.