### PR TITLE
회의 추천 시간 불러오는 API 연동하기

### DIFF
--- a/src/hooks/api/room/schedule/getRecommend.ts
+++ b/src/hooks/api/room/schedule/getRecommend.ts
@@ -1,0 +1,30 @@
+import { useQuery } from '@tanstack/react-query';
+
+import customAxios, { requestIntercepter } from '../../../../api/customAxios';
+
+type GetRecommendTimeRequest = {
+  roomId: number;
+  date: string;
+};
+
+type GetRecommendTimeResponse = {
+  recommendTime: {
+    startTime: string;
+    endTime: string;
+  }[];
+};
+
+type GetRecommendTime = (
+  query: GetRecommendTimeRequest
+) => Promise<GetRecommendTimeResponse>;
+
+// access token 검증 오류가 해결될 때까지 토큰을 싣지 않고 요청.
+customAxios.interceptors.request.eject(requestIntercepter);
+
+const getRecommandTime: GetRecommendTime = async (query) =>
+  customAxios.get('/room/schedule/recommend', { params: query });
+
+const useGetRecommendTime = (query: GetRecommendTimeRequest) =>
+  useQuery(['getRecommendTime'], () => getRecommandTime(query));
+
+export default useGetRecommendTime;

--- a/src/hooks/api/room/schedule/searchSchedule.ts
+++ b/src/hooks/api/room/schedule/searchSchedule.ts
@@ -28,12 +28,14 @@ type SearchRoomScheduleResponse = {
   last: boolean;
 };
 
+type GetSearchRoomSchedules = (
+  query: SearchRoomScheduleRequest
+) => Promise<SearchRoomScheduleResponse>;
+
 // access token 검증 오류가 해결될 때까지 토큰을 싣지 않고 요청.
 customAxios.interceptors.request.eject(requestIntercepter);
 
-const getSearchRoomSchedules = async (
-  query: SearchRoomScheduleRequest
-): Promise<SearchRoomScheduleResponse> => {
+const getSearchRoomSchedules: GetSearchRoomSchedules = async (query) => {
   const { data } = await customAxios.get('/room/schedule/search', {
     params: query
   });

--- a/src/pages/group/meeting/suggestion/index.tsx
+++ b/src/pages/group/meeting/suggestion/index.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 
 import { Button, Logo, SuggestionTimeList } from '../../../../components/atoms';
 import { TopNavBar } from '../../../../components/molecules';
+import useGetRecommendTime from '../../../../hooks/api/room/schedule/getRecommend';
 import colors from '../../../../styles/colors';
 import { semiBold16, semiBold20 } from '../../../../styles/typography';
 
@@ -82,9 +83,20 @@ const AddTimeButton = styled(Button)`
 `;
 
 const Suggestion = () => {
+  const {
+    data: recommendTimes,
+    isError: isRecommendTimeError,
+    isLoading: isRecommendTimeLoading
+  } = useGetRecommendTime({ roomId: 66, date: '2022-11-04' });
+  // TODO: roomId는 API에서 받아온 값으로, date는 현재 날짜로 변경해야 함
+
   const handleClickAddMenually = () => Router.push('./add');
 
   const handleBackButtonClick = () => Router.push('./');
+
+  if (isRecommendTimeLoading) return <div>추천 시간 로딩중...</div>;
+  if (isRecommendTimeError) return <div>추천 시간 불러오기 에러!</div>;
+  if (recommendTimes === undefined) return <div>추천 시간 데이터 에러!</div>;
 
   return (
     <>
@@ -97,6 +109,7 @@ const Suggestion = () => {
               <EditLink>수정</EditLink>
             </Link>
           </TitleContainer>
+          {/* TODO: API에서 받아온 추천시간으로 대체하기. */}
           {SUGGESTION_TIME_MOCK.map(({ date, time }) => (
             <SuggestionTimeListStyled key={date + time} {...{ date, time }} />
           ))}


### PR DESCRIPTION
resolved #208

- 추천 회의 시간을 불러올 수 있는 API를 연동했습니다.
- 아직 API가 정상작동하지 않아 구현만 한 상태이며, 테스트는 나중에 할 예정입니다.
- 그룹 관련 API 연동이 아직 되지 않아서, 추천 시간 조회에 필요한 `roomId`와 `date`는 임시 데이터로 집어넣었습니다.
- 추가로, `useSearchRoomSchedules`에서 타입 선언부를 조금 수정했습니다.