### PR TITLE
모임 홈과 회의 탭에서 API가 보내준 회의 리스트 보여주기

### DIFF
--- a/src/__mocks__/index.ts
+++ b/src/__mocks__/index.ts
@@ -13,11 +13,11 @@ export const MEETINGS_MOCK = [
     location: '선릉역 SWM 센터 7층 회의실',
     date: '2022.09.01 (목)',
     participants: [
-      { id: 1, URL: DEMO_PROFILE_IMAGE_URL },
-      { id: 2, URL: DEMO_PROFILE_IMAGE_URL },
-      { id: 3, URL: DEMO_PROFILE_IMAGE_URL },
-      { id: 4, URL: DEMO_PROFILE_IMAGE_URL },
-      { id: 5, URL: DEMO_PROFILE_IMAGE_URL }
+      DEMO_PROFILE_IMAGE_URL,
+      DEMO_PROFILE_IMAGE_URL,
+      DEMO_PROFILE_IMAGE_URL,
+      DEMO_PROFILE_IMAGE_URL,
+      DEMO_PROFILE_IMAGE_URL
     ]
   },
   {
@@ -26,16 +26,11 @@ export const MEETINGS_MOCK = [
     location: '선릉역 SWM 센터 7층 회의실',
     date: '2022.09.01 (목)',
     participants: [
-      { id: 6, URL: DEMO_PROFILE_IMAGE_URL },
-      { id: 7, URL: DEMO_PROFILE_IMAGE_URL },
-      { id: 8, URL: DEMO_PROFILE_IMAGE_URL },
-      { id: 9, URL: DEMO_PROFILE_IMAGE_URL },
-      { id: 10, URL: DEMO_PROFILE_IMAGE_URL },
-      { id: 11, URL: DEMO_PROFILE_IMAGE_URL },
-      { id: 12, URL: DEMO_PROFILE_IMAGE_URL },
-      { id: 13, URL: DEMO_PROFILE_IMAGE_URL },
-      { id: 14, URL: DEMO_PROFILE_IMAGE_URL },
-      { id: 15, URL: DEMO_PROFILE_IMAGE_URL }
+      DEMO_PROFILE_IMAGE_URL,
+      DEMO_PROFILE_IMAGE_URL,
+      DEMO_PROFILE_IMAGE_URL,
+      DEMO_PROFILE_IMAGE_URL,
+      DEMO_PROFILE_IMAGE_URL
     ]
   },
   {
@@ -44,9 +39,11 @@ export const MEETINGS_MOCK = [
     location: '선릉역 SWM 센터 7층 회의실',
     date: '2022.09.01 (목)',
     participants: [
-      { id: 16, URL: DEMO_PROFILE_IMAGE_URL },
-      { id: 17, URL: DEMO_PROFILE_IMAGE_URL },
-      { id: 18, URL: DEMO_PROFILE_IMAGE_URL }
+      DEMO_PROFILE_IMAGE_URL,
+      DEMO_PROFILE_IMAGE_URL,
+      DEMO_PROFILE_IMAGE_URL,
+      DEMO_PROFILE_IMAGE_URL,
+      DEMO_PROFILE_IMAGE_URL
     ]
   }
 ];

--- a/src/components/molecules/MeetingCard/MeetingCard.stories.tsx
+++ b/src/components/molecules/MeetingCard/MeetingCard.stories.tsx
@@ -12,8 +12,18 @@ export default {
 
 export const Primary: ComponentStory<typeof MeetingCard> = ({
   title = '회의 제목',
-  location = '회의하는 곳의 주소',
-  date = '2022년 10월 21일',
-  participants = PARTICIPANT_MOCK,
+  address: location = '회의하는 곳의 주소',
+  startTime: date = '2022년 10월 21일',
+  profiles: participants = PARTICIPANT_MOCK,
   editLink = ''
-}) => <MeetingCard {...{ title, location, date, participants, editLink }} />;
+}) => (
+  <MeetingCard
+    {...{
+      title,
+      address: location,
+      startTime: date,
+      profiles: participants,
+      editLink
+    }}
+  />
+);

--- a/src/components/molecules/MeetingCard/index.tsx
+++ b/src/components/molecules/MeetingCard/index.tsx
@@ -3,16 +3,15 @@ import Link from 'next/link';
 import styled from '@emotion/styled';
 
 import { useAdjustNumberOfProfiles } from '../../../hooks';
-import { Participant } from '../../../pages/group';
 import colors from '../../../styles/colors';
 import { medium12, semiBold16, semiBold20 } from '../../../styles/typography';
 import { Avatar } from '../../atoms';
 
 type Props = {
   title: string;
-  location: string;
-  date: string;
-  participants: Participant[];
+  address: string;
+  startTime: string;
+  profiles: string[];
   editLink?: string;
 };
 
@@ -67,14 +66,14 @@ const ProfileImage = styled(Avatar)`
 
 const MeetingCard = ({
   title,
-  location,
-  date,
-  participants,
+  address,
+  startTime,
+  profiles,
   editLink
 }: Props) => {
   const cardRef = useRef<HTMLDivElement>(null);
   const { numberOfOverflow, participantsToShow } = useAdjustNumberOfProfiles({
-    participants,
+    profiles,
     cardWidth: cardRef.current?.clientWidth ?? 0
   });
 
@@ -88,11 +87,11 @@ const MeetingCard = ({
           </Link>
         )}
       </TitleContainer>
-      <MeetingLocation>{location}</MeetingLocation>
-      <MeetingDate>{date}</MeetingDate>
+      <MeetingLocation>{address}</MeetingLocation>
+      <MeetingDate>{startTime}</MeetingDate>
       <ProfileImageContainer ref={cardRef}>
-        {participantsToShow.map(({ id, URL }) => (
-          <ProfileImage proptype="image" key={id} src={URL} />
+        {participantsToShow.map((URL) => (
+          <ProfileImage proptype="image" key={URL} src={URL} />
         ))}
         {numberOfOverflow !== 0 && (
           <ProfileImage proptype="more-profile" count={numberOfOverflow} />

--- a/src/hooks/api/team-schedule/getSchedules.ts
+++ b/src/hooks/api/team-schedule/getSchedules.ts
@@ -14,18 +14,22 @@ type GetTeamSchedulesRequest = {
 
 type GetTeamSchedulesResponse = {
   success: boolean;
-  teamScheduleList: {
-    title: string;
-    startTime: string;
-    meetingLocation: {
-      address: string;
-      longitude: string;
-      latitude: string;
-    };
-    profiles: string[];
-  }[];
-  page: number;
-  last: boolean;
+  data: {
+    teamScheduleList: {
+      id: number;
+      title: string;
+      startTime: string;
+      meetingLocation: {
+        address: string;
+        longitude: string;
+        latitude: string;
+      };
+      profiles: string[];
+    }[];
+    page: number;
+    last: boolean;
+  };
+  error: string | null;
 };
 
 type GetSearchRoomSchedules = (
@@ -43,6 +47,8 @@ const getTeamSchedules: GetSearchRoomSchedules = async (query) => {
 };
 
 const useGetTeamSchedules = (query: GetTeamSchedulesRequest) =>
-  useQuery(['getTeamSchedules'], () => getTeamSchedules(query));
+  useQuery(['getTeamSchedules'], () => getTeamSchedules(query), {
+    select: (data) => data.data
+  });
 
 export default useGetTeamSchedules;

--- a/src/hooks/useAdjustNumberOfProfiles.tsx
+++ b/src/hooks/useAdjustNumberOfProfiles.tsx
@@ -1,35 +1,31 @@
 import { useEffect, useState } from 'react';
 
-import { Participant } from '../pages/group';
-
 const PROFILE_IMAGE_WIDTH = 44 + 8; // 44px: width of profile image, 8px: margin-right
 const CARD_PADDING = 24; // 24px: padding of card
 
 type Props = {
-  participants: Participant[];
+  profiles: string[];
   cardWidth: number;
 };
 
-const useAdjustNumberOfProfiles = ({ participants, cardWidth }: Props) => {
+const useAdjustNumberOfProfiles = ({ profiles, cardWidth }: Props) => {
   const [numberOfOverflow, setNumberOfOverflow] = useState(0);
-  const [participantsToShow, setParticipantsToShow] = useState<Participant[]>(
-    []
-  );
+  const [participantsToShow, setParticipantsToShow] = useState<string[]>([]);
 
   useEffect(() => {
-    const numberOfParticipants = participants.length;
+    const numberOfParticipants = profiles.length;
     const numbeofCanbeShown = Math.floor(
       (cardWidth - CARD_PADDING) / PROFILE_IMAGE_WIDTH
     );
     if (numberOfParticipants > numbeofCanbeShown) {
       const numberOfOverflow = numberOfParticipants - numbeofCanbeShown;
-      setParticipantsToShow(participants.slice(0, numbeofCanbeShown - 1));
+      setParticipantsToShow(profiles.slice(0, numbeofCanbeShown - 1));
       setNumberOfOverflow(numberOfOverflow);
       return;
     }
-    setParticipantsToShow(participants);
+    setParticipantsToShow(profiles);
     setNumberOfOverflow(0);
-  }, [participants, cardWidth]);
+  }, [profiles, cardWidth]);
 
   return { numberOfOverflow, participantsToShow };
 };

--- a/src/pages/group/index.tsx
+++ b/src/pages/group/index.tsx
@@ -1,8 +1,8 @@
 import styled from '@emotion/styled';
 
-import { MEETINGS_MOCK } from '../../__mocks__';
 import { MeetingCard } from '../../components/molecules';
 import { GroupPage } from '../../components/templates';
+import useGetTeamSchedules from '../../hooks/api/team-schedule/getSchedules';
 import colors from '../../styles/colors';
 import { semiBold16 } from '../../styles/typography';
 
@@ -19,12 +19,26 @@ const SubTitle = styled.h2`
 `;
 
 const Home = () => {
+  const {
+    data: schedules,
+    isLoading: isSchedulesLoading,
+    isError: isSchedulesError
+  } = useGetTeamSchedules({ roomId: 66 });
+
+  if (isSchedulesLoading) return <div>스케쥴 로딩중...</div>;
+  if (isSchedulesError) return <div>스케쥴 로딩 에러!</div>;
+  if (schedules === undefined) return <div>스케쥴 데이터 오류!</div>;
+
+  const { teamScheduleList } = schedules;
+
   return (
     <GroupPage selectedTabIndex={0} groupName={GROUP_NAME_MOCK}>
       <SubTitle>가까운 회의 일정</SubTitle>
-      {MEETINGS_MOCK.map(({ id, title, location, date, participants }) => (
-        <MeetingCard key={id} {...{ title, location, date, participants }} />
-      ))}
+      {teamScheduleList.map(
+        ({ id, title, meetingLocation: { address }, startTime, profiles }) => (
+          <MeetingCard key={id} {...{ title, address, startTime, profiles }} />
+        )
+      )}
     </GroupPage>
   );
 };

--- a/src/pages/group/meeting/index.tsx
+++ b/src/pages/group/meeting/index.tsx
@@ -1,6 +1,6 @@
 import Router from 'next/router';
 
-import { GROUP_NAME_MOCK, MEETINGS_MOCK } from '../../../__mocks__';
+import { GROUP_NAME_MOCK } from '../../../__mocks__';
 import { MeetingCard } from '../../../components/molecules';
 import ButtonFooter from '../../../components/molecules/ButtonFooter';
 import { GroupPage } from '../../../components/templates';
@@ -19,19 +19,31 @@ const Meeting = () => {
   if (isSchedulesError) return <div>스케쥴 로딩 에러!</div>;
   if (schedules === undefined) return <div>스케쥴 데이터 오류!</div>;
 
-  console.log(schedules);
+  const { teamScheduleList } = schedules;
 
   return (
     <>
       <GroupPage groupName={GROUP_NAME_MOCK} selectedTabIndex={1}>
-        {/* TODO: 스케쥴 조회 API 수정되면 목데이터 교체하기 */}
-        {MEETINGS_MOCK.map(({ id, title, location, date, participants }) => (
-          <MeetingCard
-            key={id}
-            {...{ title, location, date, participants }}
-            editLink="./meeting"
-          />
-        ))}
+        {teamScheduleList.map(
+          ({
+            id,
+            title,
+            meetingLocation: { address },
+            startTime,
+            profiles
+          }) => (
+            <MeetingCard
+              key={id}
+              {...{
+                title,
+                address,
+                startTime,
+                profiles
+              }}
+              editLink="./meeting"
+            />
+          )
+        )}
         <ButtonFooter disabled={false} onClick={handleClickFooterButton}>
           회의 만들기
         </ButtonFooter>


### PR DESCRIPTION
resolved #212

- 모임 홈과 회의 탭에서 목 데이터 말고 API로부터 받은 실제 회의 리스트를 보여주는 작업을 했습니다.
-`GET /team-schedule` API에서 추가될 회의 `id` 필드를 미리 반환 타입에 추가했습니다.
- 반환값에서 `data`에 해당하는 값만 컴포넌트에서 사용할 수 있도록 `useQuery`에서 정제 과정을 거쳤습니다.