### PR TITLE
API에서 불러온 회의 추천 시간 목록을 보여주기

### DIFF
--- a/src/components/atoms/SuggestionTimeList/index.tsx
+++ b/src/components/atoms/SuggestionTimeList/index.tsx
@@ -3,26 +3,37 @@ import styled from '@emotion/styled';
 
 import colors from '../../../styles/colors';
 import { regular16, semiBold16 } from '../../../styles/typography';
+import makeDateTimeString from '../../../utils/makeDatetimeString';
 
 type Props = {
   className?: string;
-  date: string;
-  time: string;
+  startTime: string;
+  endTime: string;
   href?: string;
 };
 
 const LinkContainer = styled.a`
-  display: block;
+  display: flex;
+  align-items: center;
   padding: 16px 20px;
   background-color: ${colors.grayScale.white};
+  border-bottom: 1px solid ${colors.grayScale.gray02};
   text-decoration: none;
 `;
 
 const Container = styled.div`
-  display: block;
+  display: flex;
+  align-items: center;
   padding: 16px 20px;
   background-color: ${colors.grayScale.white};
+  border-bottom: 1px solid ${colors.grayScale.gray02};
   text-decoration: none;
+`;
+
+const Tilde = styled.span`
+  margin: 0 30px;
+  ${regular16}
+  color: ${colors.grayScale.gray03};
 `;
 
 const Date = styled.span`
@@ -36,18 +47,43 @@ const Time = styled.span`
   color: ${colors.grayScale.gray03};
 `;
 
-const SuggestionTimeList = ({ className, date, time, href }: Props) => {
+type DateAndTimeProps = Pick<Props, 'startTime' | 'endTime'>;
+
+const DateAndTime = ({ startTime, endTime }: DateAndTimeProps) => {
+  const { dateString: startDateString, timeString: startTimeString } =
+    makeDateTimeString(startTime);
+  const { dateString: endDateString, timeString: endTimeString } =
+    makeDateTimeString(endTime);
+  return (
+    <>
+      <div>
+        <Date>{startDateString}</Date>
+        <Time>{startTimeString}</Time>
+      </div>
+      <Tilde>~</Tilde>
+      <div>
+        <Date>{endDateString}</Date>
+        <Time>{endTimeString}</Time>
+      </div>
+    </>
+  );
+};
+
+const SuggestionTimeList = ({ className, startTime, endTime, href }: Props) => {
+  const { dateString: startDateString, timeString: startTimeString } =
+    makeDateTimeString(startTime);
+  const { dateString: endDateString, timeString: endTimeString } =
+    makeDateTimeString(endTime);
+
   return href ? (
     <Link passHref href={href}>
-      <LinkContainer className={className}>
-        <Date>{date}</Date>
-        <Time>{time}</Time>
+      <LinkContainer>
+        <DateAndTime {...{ startTime, endTime }} />
       </LinkContainer>
     </Link>
   ) : (
     <Container className={className}>
-      <Date>{date}</Date>
-      <Time>{time}</Time>
+      <DateAndTime {...{ startTime, endTime }} />
     </Container>
   );
 };

--- a/src/hooks/api/room/getRecommend.ts
+++ b/src/hooks/api/room/getRecommend.ts
@@ -7,16 +7,14 @@ type GetRecommendTimeRequest = {
   roomId: number;
 };
 
-type GetRecommendTimeResponse = {
-  recommendTime: {
-    startTime: string;
-    endTime: string;
-  }[];
-};
+type GetRecommendTimeData = {
+  startTime: string;
+  endTime: string;
+}[];
 
 type GetRecommendTime = (
   query: GetRecommendTimeRequest
-) => Promise<GetRecommendTimeResponse>;
+) => Promise<GroomApiResponse<GetRecommendTimeData>>;
 
 // access token 검증 오류가 해결될 때까지 토큰을 싣지 않고 요청.
 customAxios.interceptors.request.eject(requestIntercepter);
@@ -25,6 +23,8 @@ const getRecommandTime: GetRecommendTime = async ({ roomId, query }) =>
   customAxios.get(`/room/${roomId}/schedule/recommend`, { params: query });
 
 const useGetRecommendTime = (query: GetRecommendTimeRequest) =>
-  useQuery(['getRecommendTime'], () => getRecommandTime(query));
+  useQuery(['getRecommendTime'], () => getRecommandTime(query), {
+    select: (data) => data.data
+  });
 
 export default useGetRecommendTime;

--- a/src/hooks/api/room/getRecommend.ts
+++ b/src/hooks/api/room/getRecommend.ts
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 
-import customAxios, { requestIntercepter } from '../../../api/customAxios';
+import customAxios from '../../../api/customAxios';
 
 type GetRecommendTimeRequest = {
   query: { date: string };
@@ -15,9 +15,6 @@ type GetRecommendTimeData = {
 type GetRecommendTime = (
   query: GetRecommendTimeRequest
 ) => Promise<GroomApiResponse<GetRecommendTimeData>>;
-
-// access token 검증 오류가 해결될 때까지 토큰을 싣지 않고 요청.
-customAxios.interceptors.request.eject(requestIntercepter);
 
 const getRecommandTime: GetRecommendTime = async ({ roomId, query }) => {
   const { data } = await customAxios.get(`/room/${roomId}/schedule/recommend`, {

--- a/src/hooks/api/room/getRecommend.ts
+++ b/src/hooks/api/room/getRecommend.ts
@@ -19,8 +19,12 @@ type GetRecommendTime = (
 // access token 검증 오류가 해결될 때까지 토큰을 싣지 않고 요청.
 customAxios.interceptors.request.eject(requestIntercepter);
 
-const getRecommandTime: GetRecommendTime = async ({ roomId, query }) =>
-  customAxios.get(`/room/${roomId}/schedule/recommend`, { params: query });
+const getRecommandTime: GetRecommendTime = async ({ roomId, query }) => {
+  const { data } = await customAxios.get(`/room/${roomId}/schedule/recommend`, {
+    params: query
+  });
+  return data;
+};
 
 const useGetRecommendTime = (query: GetRecommendTimeRequest) =>
   useQuery(['getRecommendTime'], () => getRecommandTime(query), {

--- a/src/hooks/api/team-schedule/getSchedules.ts
+++ b/src/hooks/api/team-schedule/getSchedules.ts
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 
-import customAxios, { requestIntercepter } from '../../../api/customAxios';
+import customAxios from '../../../api/customAxios';
 
 type GetTeamSchedulesRequest = {
   page?: number;
@@ -12,32 +12,25 @@ type GetTeamSchedulesRequest = {
   endTime?: string;
 };
 
-type GetTeamSchedulesResponse = {
-  success: boolean;
-  data: {
-    teamScheduleList: {
-      id: number;
-      title: string;
-      startTime: string;
-      meetingLocation: {
-        address: string;
-        longitude: string;
-        latitude: string;
-      };
-      profiles: string[];
-    }[];
-    page: number;
-    last: boolean;
-  };
-  error: string | null;
+type GetTeamSchedulesData = {
+  teamScheduleList: {
+    id: number;
+    title: string;
+    startTime: string;
+    meetingLocation: {
+      address: string;
+      longitude: string;
+      latitude: string;
+    };
+    profiles: string[];
+  }[];
+  page: number;
+  last: boolean;
 };
 
 type GetSearchRoomSchedules = (
   query: GetTeamSchedulesRequest
-) => Promise<GetTeamSchedulesResponse>;
-
-// access token 검증 오류가 해결될 때까지 토큰을 싣지 않고 요청.
-customAxios.interceptors.request.eject(requestIntercepter);
+) => Promise<GroomApiResponse<GetTeamSchedulesData>>;
 
 const getTeamSchedules: GetSearchRoomSchedules = async (query) => {
   const { data } = await customAxios.get('/team-schedule', {

--- a/src/hooks/api/team-schedule/postSchedule.ts
+++ b/src/hooks/api/team-schedule/postSchedule.ts
@@ -15,14 +15,14 @@ type PostTeamSchedulesReqeust = {
   participantsIds: number[];
 };
 
-type PostTeamSchedulesResponse = {
-  success: boolean;
-  data: Omit<PostTeamSchedulesReqeust, 'participantsIds' | 'roomId'>;
-};
+type PostTeamSchedulesData = Omit<
+  PostTeamSchedulesReqeust,
+  'participantsIds' | 'roomId'
+>;
 
 type PostNewRoomSchedule = (
   body: PostTeamSchedulesReqeust
-) => Promise<PostTeamSchedulesResponse>;
+) => Promise<GroomApiResponse<PostTeamSchedulesData>>;
 
 // access token 검증 오류가 해결될 때까지 토큰을 싣지 않고 요청.
 customAxios.interceptors.request.eject(requestIntercepter);

--- a/src/pages/group/meeting/suggestion/index.tsx
+++ b/src/pages/group/meeting/suggestion/index.tsx
@@ -109,7 +109,6 @@ const Suggestion = () => {
               <EditLink>수정</EditLink>
             </Link>
           </TitleContainer>
-          {/* TODO: API에서 받아온 추천시간으로 대체하기. */}
           {recommendTimes.map(({ startTime, endTime }) => (
             <SuggestionTimeListStyled
               key={startTime + endTime}

--- a/src/pages/group/meeting/suggestion/index.tsx
+++ b/src/pages/group/meeting/suggestion/index.tsx
@@ -98,8 +98,6 @@ const Suggestion = () => {
   if (isRecommendTimeError) return <div>추천 시간 불러오기 에러!</div>;
   if (recommendTimes === undefined) return <div>추천 시간 데이터 에러!</div>;
 
-  console.log(recommendTimes);
-
   return (
     <>
       <TopNavBar setting={false} onBackButtonClick={handleBackButtonClick} />

--- a/src/pages/group/meeting/suggestion/index.tsx
+++ b/src/pages/group/meeting/suggestion/index.tsx
@@ -11,31 +11,31 @@ import { semiBold16, semiBold20 } from '../../../../styles/typography';
 const SUGGESTION_TIME_MOCK = [
   {
     date: '2022.09.01 (목)',
-    time: '오전 10:00 ~ 오후 12:00'
+    time: '오전 10:00'
   },
   {
     date: '2022.09.02 (목)',
-    time: '오전 10:00 ~ 오후 12:00'
+    time: '오전 10:00'
   },
   {
     date: '2022.09.03 (목)',
-    time: '오전 10:00 ~ 오후 12:00'
+    time: '오전 10:00'
   },
   {
     date: '2022.09.04 (목)',
-    time: '오전 10:00 ~ 오후 12:00'
+    time: '오전 10:00'
   },
   {
     date: '2022.09.05 (목)',
-    time: '오전 10:00 ~ 오후 12:00'
+    time: '오전 10:00'
   },
   {
     date: '2022.09.06 (목)',
-    time: '오전 10:00 ~ 오후 12:00'
+    time: '오전 10:00'
   },
   {
     date: '2022.09.07 (목)',
-    time: '오전 10:00 ~ 오후 12:00'
+    time: '오전 10:00'
   }
 ];
 
@@ -98,6 +98,8 @@ const Suggestion = () => {
   if (isRecommendTimeError) return <div>추천 시간 불러오기 에러!</div>;
   if (recommendTimes === undefined) return <div>추천 시간 데이터 에러!</div>;
 
+  console.log(recommendTimes);
+
   return (
     <>
       <TopNavBar setting={false} onBackButtonClick={handleBackButtonClick} />
@@ -110,8 +112,11 @@ const Suggestion = () => {
             </Link>
           </TitleContainer>
           {/* TODO: API에서 받아온 추천시간으로 대체하기. */}
-          {SUGGESTION_TIME_MOCK.map(({ date, time }) => (
-            <SuggestionTimeListStyled key={date + time} {...{ date, time }} />
+          {recommendTimes.map(({ startTime, endTime }) => (
+            <SuggestionTimeListStyled
+              key={startTime + endTime}
+              {...{ startTime, endTime }}
+            />
           ))}
         </>
       ) : (

--- a/src/types/groomApi.d.ts
+++ b/src/types/groomApi.d.ts
@@ -1,0 +1,5 @@
+type GroomApiResponse<T> = {
+  success: boolean;
+  data: T;
+  error: string | null;
+};

--- a/src/utils/makeDatetimeString.ts
+++ b/src/utils/makeDatetimeString.ts
@@ -1,0 +1,21 @@
+const makeDateTimeString = (datetime: string) => {
+  const datetimeList = datetime.split('T');
+  const date = datetimeList[0];
+  const time = datetimeList[1];
+  const dateList = date.split('-');
+  const year = dateList[0];
+  const month = dateList[1];
+  const day = dateList[2];
+  const timeList = time.split(':');
+  const hour = parseInt(timeList[0]);
+  const minute = timeList[1];
+  const ampm = hour < 12 ? '오전' : '오후';
+  const hour12 = hour > 12 ? hour - 12 : hour;
+
+  return {
+    dateString: `${year}년 ${month}월 ${day}일`,
+    timeString: `${ampm} ${hour12}:${minute}`
+  };
+};
+
+export default makeDateTimeString;


### PR DESCRIPTION
resolved #215

- 목데이터를 API에서 받아온 회의 추천 시간 데이터로 바꾸는 작업을 했습니다.
- 디자인 가이드와 마크업을 비교하다 목록의 각 아이템에 하단 경계선이 빠진 것을 깨달아 이번 PR에서 추가했습니다.
- 추천 시간을 일 단위로 주는 것에서 가능한 시간 묶음을 주는 방식으로 정책이 바뀌어 API 반환값에 맞게 UI를 조금 수정했습니다.