### PR TITLE
초대코드 탭 마크업 및 코드 불러오는 API 연동하기

### DIFF
--- a/src/components/templates/GroupPage/index.tsx
+++ b/src/components/templates/GroupPage/index.tsx
@@ -2,6 +2,7 @@ import { ReactNode } from 'react';
 import Router from 'next/router';
 import styled from '@emotion/styled';
 
+import useGetDetailWithRoomId from '../../../hooks/api/room/getDetailWithRoomId';
 import colors from '../../../styles/colors';
 import { semiBold20 } from '../../../styles/typography';
 import { Tab } from '../../atoms';
@@ -10,7 +11,6 @@ import { TopNavBar } from '../../molecules';
 type Props = {
   roomId: number;
   className?: string;
-  groupName: string;
   selectedTabIndex: 0 | 1 | 2 | 3;
   children: ReactNode;
 };
@@ -53,11 +53,19 @@ const ContentBox = styled.div`
 const GroupPage = ({
   roomId,
   className,
-  groupName,
   selectedTabIndex,
   children
 }: Props) => {
   const handleBackButtonClick = () => Router.push('/home');
+  const {
+    data: roomDetail,
+    isError: isRoomDetailError,
+    isLoading: isRoomDetailLoading
+  } = useGetDetailWithRoomId(roomId);
+
+  if (isRoomDetailError) return <div>그룹 정보 에러!</div>;
+  if (isRoomDetailLoading) return <div>그룹 정보 로딩중...</div>;
+  if (roomDetail === undefined) return <div>그룹 정보 없음!</div>;
 
   return (
     <Background className={className}>
@@ -66,7 +74,7 @@ const GroupPage = ({
         settingURL={`/group/setting/information?roomId=${roomId}`}
         onBackButtonClick={handleBackButtonClick}
       />
-      <GroupName>{groupName}</GroupName>
+      <GroupName>{roomDetail.name}</GroupName>
       <NavigationBox>
         <Tab
           isSelected={selectedTabIndex === TAB_INDEX.FIRST}
@@ -93,7 +101,7 @@ const GroupPage = ({
           isSelected={selectedTabIndex === TAB_INDEX.FOURTH}
           htmlFor=""
           // TODO: 초대 코드 복사 페이지로 이동시키기.
-          href={`/group/meeting?roomId=${roomId}`}
+          href={`/group/invite?roomId=${roomId}`}
         >
           초대하기
         </Tab>

--- a/src/hooks/api/room/getInviteCode.ts
+++ b/src/hooks/api/room/getInviteCode.ts
@@ -1,0 +1,22 @@
+import { useQuery } from '@tanstack/react-query';
+
+import customAxios from '../../../api/customAxios';
+
+type GetInviteCodeRespones = GroomApiResponse<{
+  code: string;
+}>;
+
+type GetInviteCode = (roomId: number) => Promise<GetInviteCodeRespones>;
+
+const getInviteCode: GetInviteCode = async (roomId) => {
+  const { data } = await customAxios.get(`/room/${roomId}/code`);
+  return data;
+};
+
+const useGetInviteCode = (roomId: number) =>
+  useQuery(['inviteCode'], () => getInviteCode(roomId), {
+    enabled: !!roomId,
+    select: (data) => data.data.code
+  });
+
+export default useGetInviteCode;

--- a/src/pages/group/invite.tsx
+++ b/src/pages/group/invite.tsx
@@ -1,0 +1,61 @@
+import styled from '@emotion/styled';
+
+import { GroupPage } from '../../components/templates';
+import { useRoomIdParams } from '../../hooks';
+import useGetInviteCode from '../../hooks/api/room/getInviteCode';
+import colors from '../../styles/colors';
+import { regular16, semiBold16, semiBold24 } from '../../styles/typography';
+
+const InviteCode = styled.span`
+  ${semiBold16}
+  display: block;
+  width: min-content;
+  margin: 44px auto 0;
+  padding: 14px 52.5px;
+  border-radius: 8px;
+  color: ${colors.grayScale.gray05};
+  background-color: ${colors.grayScale.white};
+`;
+
+const Title = styled.h1`
+  ${semiBold24}
+  display: block;
+  margin: 20px auto 0;
+  text-align: center;
+  color: ${colors.grayScale.gray05};
+`;
+
+const Description = styled.p`
+  ${regular16}
+  display: block;
+  margin: 8px auto 0;
+  text-align: center;
+  color: ${colors.grayScale.gray04};
+`;
+
+const Invite = () => {
+  const roomId = useRoomIdParams();
+  const {
+    data: inviteCode,
+    isLoading: isInviteCodeLoading,
+    isError: isInviteCodeError
+  } = useGetInviteCode(roomId);
+
+  if (isInviteCodeLoading) return <div>초대코드 로딩중...</div>;
+  if (isInviteCodeError) return <div>초대코드 로딩 실패</div>;
+  if (inviteCode === undefined) return <div>초대코드 오류</div>;
+
+  return (
+    <GroupPage roomId={roomId} selectedTabIndex={3}>
+      <InviteCode>{inviteCode}</InviteCode>
+      <Title>친구들을 초대하세요!</Title>
+      <Description>
+        친구들에게 초대코드를 전달해주면,
+        <br />
+        초대코드로 모임에 가입할 수 있어요.
+      </Description>
+    </GroupPage>
+  );
+};
+
+export default Invite;

--- a/src/pages/group/setting/information.tsx
+++ b/src/pages/group/setting/information.tsx
@@ -14,6 +14,7 @@ import {
   TopNavBar
 } from '../../../components/molecules';
 import ButtonFooter from '../../../components/molecules/ButtonFooter';
+import { useRoomIdParams } from '../../../hooks';
 import colors from '../../../styles/colors';
 import readFileAsURL from '../../../utils/readFileAsURL';
 
@@ -50,6 +51,7 @@ const TextAreaStyled = styled(TextArea)`
 `;
 
 const Information = () => {
+  const roomId = useRoomIdParams();
   const [profileImage, setProfileImage] = useState('');
   const [meetingTitle, setMeetingTitle] = useState('');
   const [meetingDescription, setMeetingDescription] = useState('');
@@ -111,7 +113,7 @@ const Information = () => {
 
   const closeMeeting = () => Router.push('/home');
 
-  const handleBackButtonClick = () => Router.push('/group');
+  const handleBackButtonClick = () => Router.push(`/group?roomId=${roomId}`);
 
   return (
     <>
@@ -122,7 +124,7 @@ const Information = () => {
             leftTabLabel="모임 정보"
             rightTabLabel="구성원 관리"
             leftTabHref=""
-            rightTabHref="./member"
+            rightTabHref={`./member?roomId=${roomId}`}
             selectedTabIndex={0}
           />
         </TabContainer>

--- a/src/pages/group/setting/member.tsx
+++ b/src/pages/group/setting/member.tsx
@@ -1,7 +1,6 @@
 import Router from 'next/router';
 import styled from '@emotion/styled';
 
-import { DEMO_PROFILE_IMAGE_URL } from '../../../__mocks__';
 import { TextButton } from '../../../components/atoms';
 import {
   MemberList,
@@ -13,46 +12,6 @@ import useGetDetailWithRoomId from '../../../hooks/api/room/getDetailWithRoomId'
 import useGetInviteCode from '../../../hooks/api/room/getInviteCode';
 import colors from '../../../styles/colors';
 import { regular16, semiBold16 } from '../../../styles/typography';
-
-const GROUP_MEMBERS_MOCK = [
-  {
-    id: 1,
-    src: DEMO_PROFILE_IMAGE_URL,
-    name: '구성원 이름'
-  },
-  {
-    id: 2,
-    src: DEMO_PROFILE_IMAGE_URL,
-    name: '구성원 이름'
-  },
-  {
-    id: 3,
-    src: DEMO_PROFILE_IMAGE_URL,
-    name: '구성원 이름'
-  },
-  {
-    id: 4,
-    src: DEMO_PROFILE_IMAGE_URL,
-    name: '구성원 이름'
-  },
-  {
-    id: 5,
-    src: DEMO_PROFILE_IMAGE_URL,
-    name: '구성원 이름'
-  },
-  {
-    id: 6,
-    src: DEMO_PROFILE_IMAGE_URL,
-    name: '구성원 이름'
-  },
-  {
-    id: 7,
-    src: DEMO_PROFILE_IMAGE_URL,
-    name: '구성원 이름'
-  }
-];
-
-const INVITE_CODE_MOCK = '122 321';
 
 const Background = styled.div`
   box-sizing: border-box;

--- a/src/pages/group/setting/member.tsx
+++ b/src/pages/group/setting/member.tsx
@@ -8,6 +8,9 @@ import {
   SegmentTab,
   TopNavBar
 } from '../../../components/molecules';
+import { useRoomIdParams } from '../../../hooks';
+import useGetDetailWithRoomId from '../../../hooks/api/room/getDetailWithRoomId';
+import useGetInviteCode from '../../../hooks/api/room/getInviteCode';
 import colors from '../../../styles/colors';
 import { regular16, semiBold16 } from '../../../styles/typography';
 
@@ -91,7 +94,34 @@ const WhiteBox = styled.div`
 `;
 
 const Member = () => {
-  const handleBackButtonClick = () => Router.push('/group');
+  const roomId = useRoomIdParams();
+  const {
+    data: inviteCode,
+    isLoading: isInviteCodeLoading,
+    isError: isInviteCodeError
+  } = useGetInviteCode(roomId);
+  const {
+    data: roomDetail,
+    isLoading: isRoomDetailLoading,
+    isError: isRoomDetailError
+  } = useGetDetailWithRoomId(roomId);
+
+  const setClipboard = (text: string) => {
+    const type = 'text/plain';
+    const blob = new Blob([text], { type });
+    const data = [new ClipboardItem({ [type]: blob })];
+
+    navigator.clipboard.write(data);
+  };
+
+  const handleBackButtonClick = () => Router.push(`/group?roomId=${roomId}`);
+
+  if (isInviteCodeLoading) return <div>초대코드 로딩중...</div>;
+  if (isInviteCodeError) return <div>초대코드 로딩 실패</div>;
+  if (inviteCode === undefined) return <div>초대코드 에러</div>;
+  if (isRoomDetailLoading) return <div>방 정보 로딩중...</div>;
+  if (isRoomDetailError) return <div>방 정보 로딩 실패</div>;
+  if (roomDetail === undefined) return <div>방 정보 에러</div>;
 
   return (
     <Background>
@@ -100,28 +130,33 @@ const Member = () => {
         <SegmentTab
           leftTabLabel="모임 정보"
           rightTabLabel="구성원 관리"
-          leftTabHref="./information"
+          leftTabHref={`./information?roomId=${roomId}`}
           rightTabHref=""
           selectedTabIndex={1}
         />
       </TabContainer>
       <InviteCodeContainer>
         <CodeLabel>초대 코드</CodeLabel>
-        <InviteCode>{INVITE_CODE_MOCK}</InviteCode>
+        <InviteCode>{inviteCode}</InviteCode>
         <InviteCodePasteButton
           color="navy"
           disabled={false}
-          onClick={function (): void {
-            throw new Error('Function not implemented.');
-          }}
+          onClick={() => setClipboard(inviteCode)}
         >
           초대 코드 복사하기
         </InviteCodePasteButton>
       </InviteCodeContainer>
       <WhiteBox>
-        {GROUP_MEMBERS_MOCK.map(({ id, src, name }) => (
-          <MemberList key={id} check={false} {...{ src, name }} />
-        ))}
+        {roomDetail.roomParticipants.map(
+          ({ id, profileImageUrl, nickname }) => (
+            <MemberList
+              key={id}
+              check={false}
+              src={profileImageUrl}
+              name={nickname}
+            />
+          )
+        )}
       </WhiteBox>
     </Background>
   );


### PR DESCRIPTION
resolved #230

- 초대코드 탭을 마크업하고, 초대 코드를 조회하는 API를 연동했습니다.
- 추가로, 모임 설정 페이지에서 초대 코드를 조회하고 실제 팀원 정보를 볼 수 있도록 했습니다.

![image](https://user-images.githubusercontent.com/71015915/201389813-7110cae2-5467-4aba-a4db-8b10b645b6d6.png)
![image](https://user-images.githubusercontent.com/71015915/201389851-1bd97631-eceb-4533-ad67-59239d3df0ab.png)
